### PR TITLE
Refactor error handling

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["./src/**"]
+    "includes": ["./src/**", "./eslint-rules-plugin/**"]
   },
   "formatter": {
     "enabled": true,

--- a/eslint-rules-plugin/index.js
+++ b/eslint-rules-plugin/index.js
@@ -1,0 +1,11 @@
+import { throwOnlyInTry } from "./rules/throw-only-in-try.js";
+
+const plugin = {
+  meta: {
+    name: "eslint-rules-plugin",
+    version: "1.0.0",
+  },
+  rules: { "throw-only-in-try": throwOnlyInTry },
+};
+
+export default plugin;

--- a/eslint-rules-plugin/rules/throw-only-in-try.js
+++ b/eslint-rules-plugin/rules/throw-only-in-try.js
@@ -1,0 +1,53 @@
+export const throwOnlyInTry = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow throw statement outside of try, catch, or finally blocks.",
+      category: "Best Practices",
+      recommended: false,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      throwOutsideTry: "Throw statement is not allowed outside of a try block.",
+      throwInCatch: "Throw statement is not allowed inside of a catch block.",
+      throwInFinally: "Throw statement is not allowed inside of a finally block.",
+    },
+  },
+  create(context) {
+    return {
+      // Directly invoke the visitor in the ThrowStatement node.
+      ThrowStatement(node) {
+        let current = node.parent;
+
+        // Trace the parent node to check whether it is within a try/catch/finally block.
+        while (current) {
+          if (current.type === "TryStatement") {
+            // Whether the node is within a try block.
+            if (current.block.range <= node.range && node.range <= current.block.range) {
+              return; // It's within a try block, so it's fine.
+            }
+            // Whether the node is within a catch block.
+            if (
+              current.handler &&
+              current.handler.body.range <= node.range &&
+              node.range <= current.handler.body.range
+            ) {
+              context.report({ node, messageId: "throwInCatch" });
+              return;
+            }
+            // Whether the node is within a finally block.
+            if (current.finalizer && current.finalizer.range <= node.range && node.range <= current.finalizer.range) {
+              context.report({ node, messageId: "throwInFinally" });
+              return;
+            }
+          }
+          current = current.parent;
+        }
+
+        // If it is not within any try block
+        context.report({ node, messageId: "throwOutsideTry" });
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+import plugin from './eslint-rules-plugin/index.js';
+import tsParser from "@typescript-eslint/parser";
+
+export default [
+  {
+    ignores: ["node_modules/**", ".next/**"],
+  },
+  {
+    files: ['**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: 'module',
+      parserOptions: {
+        project: "./tsconfig.json",
+      },
+    },
+    plugins: {
+      'custom-rules': plugin,
+    },
+    rules: {
+      'custom-rules/throw-only-in-try': 'error',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -2,16 +2,17 @@
 	"name": "sync",
 	"version": "0.1.0",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "next dev --turbopack",
 		"build": "next build",
 		"start": "next start",
-		"lint": "biome lint",
-		"lint:write": "biome lint --write",
+		"lint": "biome lint && eslint .",
+		"lint:write": "biome lint --write && eslint .",
 		"fmt": "biome format",
 		"fmt:write": "biome format --write",
-		"check": "biome check",
-		"check:write": "biome check --write"
+		"check": "biome check && eslint .",
+		"check:write": "biome check --write && eslint ."
 	},
 	"dependencies": {
 		"next": "15.3.4",
@@ -23,6 +24,8 @@
 		"@types/node": "^20.19.12",
 		"@types/react": "^19.1.12",
 		"@types/react-dom": "^19.1.9",
+		"@typescript-eslint/parser": "^8.42.0",
+		"eslint": "^9.34.0",
 		"typescript": "^5.9.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
 	},
 	"dependencies": {
 		"next": "15.3.4",
-		"react": "^19.0.0",
-		"react-dom": "^19.0.0"
+		"react": "^19.1.1",
+		"react-dom": "^19.1.1"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.0.5",
-		"@types/node": "^20.19.1",
-		"@types/react": "^19.1.8",
-		"@types/react-dom": "^19.1.6",
-		"typescript": "^5.8.3"
+		"@biomejs/biome": "2.2.2",
+		"@types/node": "^20.19.12",
+		"@types/react": "^19.1.12",
+		"@types/react-dom": "^19.1.9",
+		"typescript": "^5.9.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.9
         version: 19.1.9(@types/react@19.1.12)
+      '@typescript-eslint/parser':
+        specifier: ^8.42.0
+        version: 8.42.0(eslint@9.34.0)(typescript@5.9.2)
+      eslint:
+        specifier: ^9.34.0
+        version: 9.34.0
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -91,6 +97,64 @@ packages:
 
   '@emnapi/runtime@1.5.0':
     resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
+
+  '@eslint-community/eslint-utils@4.8.0':
+    resolution: {integrity: sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.0':
+    resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.3.1':
+    resolution: {integrity: sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.15.2':
+    resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.34.0':
+    resolution: {integrity: sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.3.5':
+    resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.6':
+    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.3.1':
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
+    engines: {node: '>=18.18'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/sharp-darwin-arm64@0.34.3':
     resolution: {integrity: sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==}
@@ -265,11 +329,29 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@20.19.12':
     resolution: {integrity: sha512-lSOjyS6vdO2G2g2CWrETTV3Jz2zlCXHpu1rcubLKpz9oj+z/1CceHlj+yq53W+9zgb98nSov/wjEKYDNauD+Hw==}
@@ -282,12 +364,90 @@ packages:
   '@types/react@19.1.12':
     resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
 
+  '@typescript-eslint/parser@8.42.0':
+    resolution: {integrity: sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.42.0':
+    resolution: {integrity: sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/scope-manager@8.42.0':
+    resolution: {integrity: sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.42.0':
+    resolution: {integrity: sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/types@8.42.0':
+    resolution: {integrity: sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.42.0':
+    resolution: {integrity: sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.42.0':
+    resolution: {integrity: sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001739:
     resolution: {integrity: sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -306,20 +466,211 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.34.0:
+    resolution: {integrity: sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   next@15.3.4:
     resolution: {integrity: sha512-mHKd50C+mCjam/gcnwqL1T1vPx/XQNFlXqFIVdgQdVAFY9iIQtY0IfaVflEYzKiqjeA7B0cYYMaCrmAYFjs4rA==}
@@ -342,12 +693,51 @@ packages:
       sass:
         optional: true
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   react-dom@19.1.1:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
@@ -357,6 +747,17 @@ packages:
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -370,6 +771,14 @@ packages:
     resolution: {integrity: sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
@@ -380,6 +789,10 @@ packages:
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -394,8 +807,26 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
 
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
@@ -404,6 +835,22 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
 snapshots:
 
@@ -446,6 +893,63 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@eslint-community/eslint-utils@4.8.0(eslint@9.34.0)':
+    dependencies:
+      eslint: 9.34.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.21.0':
+    dependencies:
+      '@eslint/object-schema': 2.1.6
+      debug: 4.4.1
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.3.1': {}
+
+  '@eslint/core@0.15.2':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.1
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.34.0': {}
+
+  '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/plugin-kit@0.3.5':
+    dependencies:
+      '@eslint/core': 0.15.2
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.6':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.3.1
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.3.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/sharp-darwin-arm64@0.34.3':
     optionalDependencies:
@@ -559,11 +1063,27 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.3.4':
     optional: true
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@20.19.12':
     dependencies:
@@ -577,21 +1097,113 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@typescript-eslint/parser@8.42.0(eslint@9.34.0)(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.42.0
+      '@typescript-eslint/types': 8.42.0
+      '@typescript-eslint/typescript-estree': 8.42.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.42.0
+      debug: 4.4.1
+      eslint: 9.34.0
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.42.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.42.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.42.0
+      debug: 4.4.1
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.42.0':
+    dependencies:
+      '@typescript-eslint/types': 8.42.0
+      '@typescript-eslint/visitor-keys': 8.42.0
+
+  '@typescript-eslint/tsconfig-utils@8.42.0(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
+  '@typescript-eslint/types@8.42.0': {}
+
+  '@typescript-eslint/typescript-estree@8.42.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.42.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.42.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.42.0
+      '@typescript-eslint/visitor-keys': 8.42.0
+      debug: 4.4.1
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.42.0':
+    dependencies:
+      '@typescript-eslint/types': 8.42.0
+      eslint-visitor-keys: 4.2.1
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
 
+  callsites@3.1.0: {}
+
   caniuse-lite@1.0.30001739: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   client-only@0.0.1: {}
 
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-    optional: true
 
-  color-name@1.1.4:
-    optional: true
+  color-name@1.1.4: {}
 
   color-string@1.9.1:
     dependencies:
@@ -605,15 +1217,211 @@ snapshots:
       color-string: 1.9.1
     optional: true
 
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   csstype@3.1.3: {}
+
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
 
   detect-libc@2.0.4:
     optional: true
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.34.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.0
+      '@eslint/config-helpers': 0.3.1
+      '@eslint/core': 0.15.2
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.34.0
+      '@eslint/plugin-kit': 0.3.5
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.1
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flatted@3.3.3: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
   is-arrayish@0.3.2:
     optional: true
 
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  ms@2.1.3: {}
+
   nanoid@3.3.11: {}
+
+  natural-compare@1.4.0: {}
 
   next@15.3.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -640,13 +1448,46 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
   picocolors@1.1.1: {}
+
+  picomatch@2.3.1: {}
 
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
 
   react-dom@19.1.1(react@19.1.1):
     dependencies:
@@ -655,10 +1496,17 @@ snapshots:
 
   react@19.1.1: {}
 
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   scheduler@0.26.0: {}
 
-  semver@7.7.2:
-    optional: true
+  semver@7.7.2: {}
 
   sharp@0.34.3:
     dependencies:
@@ -690,6 +1538,12 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.3
     optional: true
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
@@ -699,13 +1553,43 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
+  strip-json-comments@3.1.1: {}
+
   styled-jsx@5.1.6(react@19.1.1):
     dependencies:
       client-only: 0.0.1
       react: 19.1.1
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.1.0(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
+
   tslib@2.8.1: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
 
   typescript@5.9.2: {}
 
   undici-types@6.21.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,87 +10,87 @@ importers:
     dependencies:
       next:
         specifier: 15.3.4
-        version: 15.3.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react:
-        specifier: ^19.0.0
-        version: 19.1.0
+        specifier: ^19.1.1
+        version: 19.1.1
       react-dom:
-        specifier: ^19.0.0
-        version: 19.1.0(react@19.1.0)
+        specifier: ^19.1.1
+        version: 19.1.1(react@19.1.1)
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.0.5
-        version: 2.0.5
+        specifier: 2.2.2
+        version: 2.2.2
       '@types/node':
-        specifier: ^20.19.1
-        version: 20.19.8
+        specifier: ^20.19.12
+        version: 20.19.12
       '@types/react':
-        specifier: ^19.1.8
-        version: 19.1.8
+        specifier: ^19.1.12
+        version: 19.1.12
       '@types/react-dom':
-        specifier: ^19.1.6
-        version: 19.1.6(@types/react@19.1.8)
+        specifier: ^19.1.9
+        version: 19.1.9(@types/react@19.1.12)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
 packages:
 
-  '@biomejs/biome@2.0.5':
-    resolution: {integrity: sha512-MztFGhE6cVjf3QmomWu83GpTFyWY8KIcskgRf2AqVEMSH4qI4rNdBLdpAQ11TNK9pUfLGz3IIOC1ZYwgBePtig==}
+  '@biomejs/biome@2.2.2':
+    resolution: {integrity: sha512-j1omAiQWCkhuLgwpMKisNKnsM6W8Xtt1l0WZmqY/dFj8QPNkIoTvk4tSsi40FaAAkBE1PU0AFG2RWFBWenAn+w==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.0.5':
-    resolution: {integrity: sha512-VIIWQv9Rcj9XresjCf3isBFfWjFStsdGZvm8SmwJzKs/22YQj167ge7DkxuaaZbNf2kmYif0AcjAKvtNedEoEw==}
+  '@biomejs/cli-darwin-arm64@2.2.2':
+    resolution: {integrity: sha512-6ePfbCeCPryWu0CXlzsWNZgVz/kBEvHiPyNpmViSt6A2eoDf4kXs3YnwQPzGjy8oBgQulrHcLnJL0nkCh80mlQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.0.5':
-    resolution: {integrity: sha512-DRpGxBgf5Z7HUFcNUB6n66UiD4VlBlMpngNf32wPraxX8vYU6N9cb3xQWOXIQVBBQ64QfsSLJnjNu79i/LNmSg==}
+  '@biomejs/cli-darwin-x64@2.2.2':
+    resolution: {integrity: sha512-Tn4JmVO+rXsbRslml7FvKaNrlgUeJot++FkvYIhl1OkslVCofAtS35MPlBMhXgKWF9RNr9cwHanrPTUUXcYGag==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.0.5':
-    resolution: {integrity: sha512-OpflTCOw/ElEs7QZqN/HFaSViPHjAsAPxFJ22LhWUWvuJgcy/Z8+hRV0/3mk/ZRWy5A6fCDKHZqAxU+xB6W4mA==}
+  '@biomejs/cli-linux-arm64-musl@2.2.2':
+    resolution: {integrity: sha512-/MhYg+Bd6renn6i1ylGFL5snYUn/Ct7zoGVKhxnro3bwekiZYE8Kl39BSb0MeuqM+72sThkQv4TnNubU9njQRw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.0.5':
-    resolution: {integrity: sha512-FQTfDNMXOknf8+g9Eede2daaduRjTC2SNbfWPNFMadN9K3UKjeZ62jwiYxztPaz9zQQsZU8VbddQIaeQY5CmIA==}
+  '@biomejs/cli-linux-arm64@2.2.2':
+    resolution: {integrity: sha512-JfrK3gdmWWTh2J5tq/rcWCOsImVyzUnOS2fkjhiYKCQ+v8PqM+du5cfB7G1kXas+7KQeKSWALv18iQqdtIMvzw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.0.5':
-    resolution: {integrity: sha512-9lmjCnajAzpZXbav2P6D87ugkhnaDpJtDvOH5uQbY2RXeW6Rq18uOUltxgacGBP+d8GusTr+s3IFOu7SN0Ok8g==}
+  '@biomejs/cli-linux-x64-musl@2.2.2':
+    resolution: {integrity: sha512-ZCLXcZvjZKSiRY/cFANKg+z6Fhsf9MHOzj+NrDQcM+LbqYRT97LyCLWy2AS+W2vP+i89RyRM+kbGpUzbRTYWig==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.0.5':
-    resolution: {integrity: sha512-znpfydUDPuDkyBTulnODrQVK2FaG/4hIOPcQSsF2GeauQOYrBAOplj0etGB0NUrr0dFsvaQ15nzDXYb60ACoiw==}
+  '@biomejs/cli-linux-x64@2.2.2':
+    resolution: {integrity: sha512-Ogb+77edO5LEP/xbNicACOWVLt8mgC+E1wmpUakr+O4nKwLt9vXe74YNuT3T1dUBxC/SnrVmlzZFC7kQJEfquQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.0.5':
-    resolution: {integrity: sha512-CP2wKQB+gh8HdJTFKYRFETqReAjxlcN9AlYDEoye8v2eQp+L9v+PUeDql/wsbaUhSsLR0sjj3PtbBtt+02AN3A==}
+  '@biomejs/cli-win32-arm64@2.2.2':
+    resolution: {integrity: sha512-wBe2wItayw1zvtXysmHJQoQqXlTzHSpQRyPpJKiNIR21HzH/CrZRDFic1C1jDdp+zAPtqhNExa0owKMbNwW9cQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.0.5':
-    resolution: {integrity: sha512-Sw3rz2m6bBADeQpr3+MD7Ch4E1l15DTt/+dfqKnwkm3cn4BrYwnArmvKeZdVsFRDjMyjlKIP88bw1r7o+9aqzw==}
+  '@biomejs/cli-win32-x64@2.2.2':
+    resolution: {integrity: sha512-DAuHhHekGfiGb6lCcsT4UyxQmVwQiBCBUMwVra/dcOSs9q8OhfaZgey51MlekT3p8UwRqtXQfFuEJBhJNdLZwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
 
-  '@emnapi/runtime@1.4.4':
-    resolution: {integrity: sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg==}
+  '@emnapi/runtime@1.5.0':
+    resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
 
   '@img/sharp-darwin-arm64@0.34.3':
     resolution: {integrity: sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==}
@@ -271,23 +271,23 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@types/node@20.19.8':
-    resolution: {integrity: sha512-HzbgCY53T6bfu4tT7Aq3TvViJyHjLjPNaAS3HOuMc9pw97KHsUtXNX4L+wu59g1WnjsZSko35MbEqnO58rihhw==}
+  '@types/node@20.19.12':
+    resolution: {integrity: sha512-lSOjyS6vdO2G2g2CWrETTV3Jz2zlCXHpu1rcubLKpz9oj+z/1CceHlj+yq53W+9zgb98nSov/wjEKYDNauD+Hw==}
 
-  '@types/react-dom@19.1.6':
-    resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
+  '@types/react-dom@19.1.9':
+    resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
     peerDependencies:
       '@types/react': ^19.0.0
 
-  '@types/react@19.1.8':
-    resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
+  '@types/react@19.1.12':
+    resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
-  caniuse-lite@1.0.30001727:
-    resolution: {integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==}
+  caniuse-lite@1.0.30001739:
+    resolution: {integrity: sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -349,13 +349,13 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  react-dom@19.1.0:
-    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
+  react-dom@19.1.1:
+    resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
     peerDependencies:
-      react: ^19.1.0
+      react: ^19.1.1
 
-  react@19.1.0:
-    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
+  react@19.1.1:
+    resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
 
   scheduler@0.26.0:
@@ -397,8 +397,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -407,42 +407,42 @@ packages:
 
 snapshots:
 
-  '@biomejs/biome@2.0.5':
+  '@biomejs/biome@2.2.2':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.0.5
-      '@biomejs/cli-darwin-x64': 2.0.5
-      '@biomejs/cli-linux-arm64': 2.0.5
-      '@biomejs/cli-linux-arm64-musl': 2.0.5
-      '@biomejs/cli-linux-x64': 2.0.5
-      '@biomejs/cli-linux-x64-musl': 2.0.5
-      '@biomejs/cli-win32-arm64': 2.0.5
-      '@biomejs/cli-win32-x64': 2.0.5
+      '@biomejs/cli-darwin-arm64': 2.2.2
+      '@biomejs/cli-darwin-x64': 2.2.2
+      '@biomejs/cli-linux-arm64': 2.2.2
+      '@biomejs/cli-linux-arm64-musl': 2.2.2
+      '@biomejs/cli-linux-x64': 2.2.2
+      '@biomejs/cli-linux-x64-musl': 2.2.2
+      '@biomejs/cli-win32-arm64': 2.2.2
+      '@biomejs/cli-win32-x64': 2.2.2
 
-  '@biomejs/cli-darwin-arm64@2.0.5':
+  '@biomejs/cli-darwin-arm64@2.2.2':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.0.5':
+  '@biomejs/cli-darwin-x64@2.2.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.0.5':
+  '@biomejs/cli-linux-arm64-musl@2.2.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.0.5':
+  '@biomejs/cli-linux-arm64@2.2.2':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.0.5':
+  '@biomejs/cli-linux-x64-musl@2.2.2':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.0.5':
+  '@biomejs/cli-linux-x64@2.2.2':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.0.5':
+  '@biomejs/cli-win32-arm64@2.2.2':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.0.5':
+  '@biomejs/cli-win32-x64@2.2.2':
     optional: true
 
-  '@emnapi/runtime@1.4.4':
+  '@emnapi/runtime@1.5.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -521,7 +521,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.3':
     dependencies:
-      '@emnapi/runtime': 1.4.4
+      '@emnapi/runtime': 1.5.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.3':
@@ -565,15 +565,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@types/node@20.19.8':
+  '@types/node@20.19.12':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/react-dom@19.1.6(@types/react@19.1.8)':
+  '@types/react-dom@19.1.9(@types/react@19.1.12)':
     dependencies:
-      '@types/react': 19.1.8
+      '@types/react': 19.1.12
 
-  '@types/react@19.1.8':
+  '@types/react@19.1.12':
     dependencies:
       csstype: 3.1.3
 
@@ -581,7 +581,7 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
-  caniuse-lite@1.0.30001727: {}
+  caniuse-lite@1.0.30001739: {}
 
   client-only@0.0.1: {}
 
@@ -615,17 +615,17 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@15.3.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 15.3.4
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001727
+      caniuse-lite: 1.0.30001739
       postcss: 8.4.31
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(react@19.1.0)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      styled-jsx: 5.1.6(react@19.1.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.3.4
       '@next/swc-darwin-x64': 15.3.4
@@ -648,12 +648,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  react-dom@19.1.0(react@19.1.0):
+  react-dom@19.1.1(react@19.1.1):
     dependencies:
-      react: 19.1.0
+      react: 19.1.1
       scheduler: 0.26.0
 
-  react@19.1.0: {}
+  react@19.1.1: {}
 
   scheduler@0.26.0: {}
 
@@ -699,13 +699,13 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
-  styled-jsx@5.1.6(react@19.1.0):
+  styled-jsx@5.1.6(react@19.1.1):
     dependencies:
       client-only: 0.0.1
-      react: 19.1.0
+      react: 19.1.1
 
   tslib@2.8.1: {}
 
-  typescript@5.8.3: {}
+  typescript@5.9.2: {}
 
   undici-types@6.21.0: {}

--- a/src/contexts/CircuitEditorPageHandlerContext.ts
+++ b/src/contexts/CircuitEditorPageHandlerContext.ts
@@ -2,13 +2,17 @@
 
 import { createContext, useContext } from "react";
 import type { ICircuitEditorPageHandler } from "@/domain/model/handler/ICircuitEditorPageHandler";
+import { ContextError } from "./contextError";
 
 export const CircuitEditorPageHandlerContext = createContext<ICircuitEditorPageHandler | undefined>(undefined);
 
 export const useCircuitEditorPageHandlerContext = () => {
   const ctx = useContext(CircuitEditorPageHandlerContext);
   if (ctx === undefined) {
-    throw new Error("useCircuitEditorPageHandlerContext must be used within a CircuitEditorPageHandlerContextProvider");
+    // eslint-disable-next-line custom-rules/throw-only-in-try
+    throw new ContextError(
+      "useCircuitEditorPageHandlerContext must be used within a CircuitEditorPageHandlerContextProvider",
+    );
   }
   return ctx;
 };

--- a/src/contexts/CircuitEmulationPageHandlerContext.ts
+++ b/src/contexts/CircuitEmulationPageHandlerContext.ts
@@ -2,13 +2,15 @@
 
 import { createContext, useContext } from "react";
 import type { ICircuitEmulationPageHandler } from "@/domain/model/handler/ICircuitEmulationPageHandler";
+import { ContextError } from "./contextError";
 
 export const CircuitEmulationPageHandlerContext = createContext<ICircuitEmulationPageHandler | undefined>(undefined);
 
 export const useCircuitEmulationPageHandlerContext = () => {
   const ctx = useContext(CircuitEmulationPageHandlerContext);
   if (ctx === undefined) {
-    throw new Error(
+    // eslint-disable-next-line custom-rules/throw-only-in-try
+    throw new ContextError(
       "useCircuitEmulationPageHandlerContext must be used within a CircuitEmulationPageHandlerContextProvider",
     );
   }

--- a/src/contexts/CircuitViewPageHandlerContext.ts
+++ b/src/contexts/CircuitViewPageHandlerContext.ts
@@ -2,13 +2,17 @@
 
 import { createContext, useContext } from "react";
 import type { ICircuitViewPageHandler } from "@/domain/model/handler/ICircuitViewPageHandler";
+import { ContextError } from "./contextError";
 
 export const CircuitViewPageHandlerContext = createContext<ICircuitViewPageHandler | undefined>(undefined);
 
 export const useCircuitViewPageHandlerContext = () => {
   const ctx = useContext(CircuitViewPageHandlerContext);
   if (ctx === undefined) {
-    throw new Error("useCircuitViewPageHandlerContext must be used within a CircuitViewPageHandlerContextProvider");
+    // eslint-disable-next-line custom-rules/throw-only-in-try
+    throw new ContextError(
+      "useCircuitViewPageHandlerContext must be used within a CircuitViewPageHandlerContextProvider",
+    );
   }
   return ctx;
 };

--- a/src/contexts/HomePageHandlerContext.ts
+++ b/src/contexts/HomePageHandlerContext.ts
@@ -2,14 +2,16 @@
 
 import { createContext, useContext } from "react";
 import type { IHomePageHandler } from "@/domain/model/handler/IHomePageHandler";
+import { ContextError } from "./contextError";
 
 export const HomePageHandlerContext = createContext<IHomePageHandler | undefined>(undefined);
 
 export const useHomePageHandlerContext = () => {
   const ctx = useContext(HomePageHandlerContext);
   if (ctx === undefined) {
-    throw new Error(
-      "useCircuitOverviewQueryServiceContext must be used within a CircuitOverviewQueryServiceContextProvider",
+    // eslint-disable-next-line custom-rules/throw-only-in-try
+    throw new ContextError(
+      "useHomePageHandlerContext must be used within a CircuitOverviewQueryServiceContextProvider",
     );
   }
   return ctx;

--- a/src/contexts/contextError.ts
+++ b/src/contexts/contextError.ts
@@ -1,0 +1,6 @@
+export class ContextError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContextError";
+  }
+}

--- a/src/domain/model/handler/ICircuitEditorPageHandler.ts
+++ b/src/domain/model/handler/ICircuitEditorPageHandler.ts
@@ -11,7 +11,7 @@ import type { CircuitNodeType } from "../valueObject/circuitNodeType";
 import type { CircuitTitle } from "../valueObject/circuitTitle";
 import type { Coordinate } from "../valueObject/coordinate";
 
-export interface CircuitEditorPageError {
+export interface CircuitEditorPageErrorModel {
   failedToGetCircuitDetailError: boolean;
   failedToParseCircuitDataError: boolean;
   failedToUpdateCircuitDataError: boolean;
@@ -19,7 +19,7 @@ export interface CircuitEditorPageError {
   failedToSaveCircuitError: boolean;
 }
 
-export const circuitEditorPageError: CircuitEditorPageError = {
+export const initialCircuitEditorPageError: CircuitEditorPageErrorModel = {
   failedToGetCircuitDetailError: false,
   failedToParseCircuitDataError: false,
   failedToUpdateCircuitDataError: false,
@@ -27,16 +27,32 @@ export const circuitEditorPageError: CircuitEditorPageError = {
   failedToSaveCircuitError: false,
 };
 
+export interface CircuitEditorPageUiStateModel {
+  toolbarMenu: { open: "none" | "file" | "view" | "help" };
+  diagramUtilityMenu: { open: "none" | "edge" | "node"; at: Coordinate | null };
+  toolBarMenu: { open: "none" | "file" | "view" | "goTo" | "help" };
+  activityBarMenu: { open: "infomation" | "circuitDiagram" | "rowCircuitData" };
+}
+
+export class CircuitEditorPageHandlerError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitEditorPageHandlerError";
+    this.cause = options?.cause;
+  }
+}
+
 export interface ICircuitEditorPageHandler {
-  error: CircuitEditorPageError;
+  error: CircuitEditorPageErrorModel;
+  uiState: CircuitEditorPageUiStateModel;
   circuit: Circuit | undefined;
   guiData: CircuitGuiData | undefined;
   viewBox: { x: number; y: number; w: number; h: number } | undefined;
   isPanningRef: React.RefObject<boolean>;
-  handleMouseDown: (ev: React.MouseEvent) => void;
-  handleMouseMove: (ev: React.MouseEvent) => void;
-  handleMouseUp: () => void;
-  handleWheel: (ev: React.WheelEvent) => void;
+  handleViewBoxMouseDown: (ev: React.MouseEvent) => void;
+  handleViewBoxMouseMove: (ev: React.MouseEvent) => void;
+  handleViewBoxMouseUp: () => void;
+  handleViewBoxZoom: (ev: React.WheelEvent) => void;
   preventBrowserZoom: (ref: React.RefObject<SVGSVGElement | null>) => void;
   save: () => void;
   deleteCircuit: () => void;
@@ -91,12 +107,6 @@ export interface ICircuitEditorPageHandler {
   handleWaypointMouseDown: (id: CircuitEdgeId) => (offset: Coordinate, index: number) => (ev: React.MouseEvent) => void;
   handleWaypointMouseMove: (ev: React.MouseEvent) => void;
   handleWaypointMouseUp: () => void;
-  uiState: {
-    toolbarMenu: { open: "none" | "file" | "view" | "help" };
-    diagramUtilityMenu: { open: "none" | "edge" | "node"; at: Coordinate | null };
-    toolBarMenu: { open: "none" | "file" | "view" | "goTo" | "help" };
-    activityBarMenu: { open: "infomation" | "circuitDiagram" | "rowCircuitData" };
-  };
   openUtilityMenu: (kind: "node" | "edge") => (ev: React.MouseEvent) => void;
   closeUtilityMenu: () => void;
   openToolBarMenu: (kind: "file" | "view" | "goTo" | "help") => void;

--- a/src/domain/model/handler/ICircuitEmulationPageHandler.ts
+++ b/src/domain/model/handler/ICircuitEmulationPageHandler.ts
@@ -5,22 +5,40 @@ import type { EvalResult } from "../valueObject/evalResult";
 import type { InputRecord } from "../valueObject/inputRecord";
 import type { Phase } from "../valueObject/phase";
 
-export interface CircuitEmulationPageError {
+export interface CircuitEmulationPageErrorModel {
   failedToGetCircuitDetailError: boolean;
   failedToGenGuiCircuitDataError: boolean;
   failedToSetupEmulatorServiceError: boolean;
   failedToEvalCircuitError: boolean;
 }
 
-export const circuitEmulationPageError: CircuitEmulationPageError = {
+export const initialCircuitEmulationPageError: CircuitEmulationPageErrorModel = {
   failedToGetCircuitDetailError: false,
   failedToGenGuiCircuitDataError: false,
   failedToSetupEmulatorServiceError: false,
   failedToEvalCircuitError: false,
 };
 
+export interface CircuitEmulationPageUiStateModel {
+  toolBarMenu: {
+    open: "none" | "file" | "view" | "goTo" | "help";
+  };
+  activityBarMenu: {
+    open: "evalMenu";
+  };
+}
+
+export class CircuitEmulationPageHandlerError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitEmulationPageHandlerError";
+    this.cause = options?.cause;
+  }
+}
+
 export interface ICircuitEmulationPageHandler {
-  error: CircuitEmulationPageError;
+  error: CircuitEmulationPageErrorModel;
+  uiState: CircuitEmulationPageUiStateModel;
   overview: CircuitOverview | undefined;
   guiData: CircuitGuiData | undefined;
   currentPhase: Phase;
@@ -28,14 +46,6 @@ export interface ICircuitEmulationPageHandler {
   outputs: Record<CircuitNodeId, EvalResult>;
   updateEntryInputs: (nodeID: CircuitNodeId, value: EvalResult) => void;
   evalCircuit: () => void;
-  uiState: {
-    toolBarMenu: {
-      open: "none" | "file" | "view" | "goTo" | "help";
-    };
-    activityBarMenu: {
-      open: "evalMenu";
-    };
-  };
   openToolBarMenu: (kind: "file" | "view" | "goTo" | "help") => void;
   closeToolBarMenu: () => void;
   changeActivityBarMenu: (kind: "evalMenu") => void;

--- a/src/domain/model/handler/ICircuitViewPageHandler.ts
+++ b/src/domain/model/handler/ICircuitViewPageHandler.ts
@@ -1,28 +1,38 @@
 import type { CircuitGuiData } from "../entity/circuitGuiData";
 import type { CircuitOverview } from "../entity/circuitOverview";
 
-export interface CircuitViewPageError {
+export interface CircuitViewPageErrorModel {
   failedToGetCircuitDetailError: boolean;
   failedToParseCircuitDataError: boolean;
 }
 
-export const circuitViewPageError: CircuitViewPageError = {
+export const initialCircuitViewPageError: CircuitViewPageErrorModel = {
   failedToGetCircuitDetailError: false,
   failedToParseCircuitDataError: false,
 };
 
+export interface CircuitViewPageUiStateModel {
+  toolBarMenu: {
+    open: "none" | "file" | "view" | "goTo" | "help";
+  };
+  activityBarMenu: {
+    open: "infomation" | "circuitDiagram";
+  };
+}
+
+export class CircuitViewPageHandlerError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "HomePageHandlerError";
+    this.cause = options?.cause;
+  }
+}
+
 export interface ICircuitViewPageHandler {
-  error: CircuitViewPageError;
+  error: CircuitViewPageErrorModel;
+  uiState: CircuitViewPageUiStateModel;
   overview: CircuitOverview | undefined;
   guiData: CircuitGuiData | undefined;
-  uiState: {
-    toolBarMenu: {
-      open: "none" | "file" | "view" | "goTo" | "help";
-    };
-    activityBarMenu: {
-      open: "infomation" | "circuitDiagram";
-    };
-  };
   openToolBarMenu: (kind: "file" | "view" | "goTo" | "help") => void;
   closeToolBarMenu: () => void;
   changeActivityBarMenu: (kind: "infomation" | "circuitDiagram") => void;

--- a/src/domain/model/handler/IHomePageHandler.ts
+++ b/src/domain/model/handler/IHomePageHandler.ts
@@ -4,7 +4,7 @@ export interface HomePageErrorModel {
   failedToGetCircuitOverviewsError: boolean;
 }
 
-export const initialHomePageErrorsValue: HomePageErrorModel = {
+export const initialHomePageError: HomePageErrorModel = {
   failedToGetCircuitOverviewsError: false,
 };
 

--- a/src/domain/model/handler/IHomePageHandler.ts
+++ b/src/domain/model/handler/IHomePageHandler.ts
@@ -1,18 +1,28 @@
 import type { CircuitOverview } from "../entity/circuitOverview";
 
-export interface HomePageError {
+export interface HomePageErrorModel {
   failedToGetCircuitOverviewsError: boolean;
 }
 
-export const homePageError: HomePageError = {
+export const initialHomePageErrorsValue: HomePageErrorModel = {
   failedToGetCircuitOverviewsError: false,
 };
 
+export interface HomePageUiStateModel {
+  tab: { open: "home" | "new" };
+}
+
+export class HomePageHandlerError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "HomePageHandlerError";
+    this.cause = options?.cause;
+  }
+}
+
 export interface IHomePageHandler {
-  error: HomePageError;
-  uiState: {
-    tab: { open: "home" | "new" };
-  };
+  error: HomePageErrorModel;
+  uiState: HomePageUiStateModel;
   circuitOverviews: Array<CircuitOverview> | undefined;
   changeActivityBarMenu: (kind: "home" | "new") => void;
   addNewCircuit: (kind: "empty") => void;

--- a/src/domain/model/modelValidationError.ts
+++ b/src/domain/model/modelValidationError.ts
@@ -1,0 +1,6 @@
+export class ModelValidationError extends Error {
+  constructor(modelName: string, received: unknown) {
+    super(`Invalid model: ${modelName}. Received: ${JSON.stringify(received)}`);
+    this.name = "ModelValidationError";
+  }
+}

--- a/src/domain/model/queryService/ICircuitDetailQueryService.ts
+++ b/src/domain/model/queryService/ICircuitDetailQueryService.ts
@@ -2,8 +2,14 @@ import type { Result } from "@/utils/result";
 import type { Circuit } from "../aggregate/circuit";
 import type { CircuitId } from "../valueObject/circuitId";
 
-export type CircuitDetailQueryServiceGetByIdOutput = Result<Readonly<Circuit>>;
+export class CircuitDetailQueryServiceError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitDetailQueryServiceError";
+    this.cause = options?.cause;
+  }
+}
 
 export interface ICircuitDetailQueryService {
-  getById(id: CircuitId): Promise<CircuitDetailQueryServiceGetByIdOutput>;
+  getById(id: CircuitId): Promise<Result<Circuit, CircuitDetailQueryServiceError>>;
 }

--- a/src/domain/model/queryService/ICircuitOverviewsQueryService.ts
+++ b/src/domain/model/queryService/ICircuitOverviewsQueryService.ts
@@ -1,8 +1,14 @@
 import type { Result } from "@/utils/result";
 import type { CircuitOverview } from "../entity/circuitOverview";
 
-export type CircuitOverviewsQueryServiceGetAllOutput = Result<Array<Readonly<CircuitOverview>>>;
+export class CircuitOverviewsQueryServiceError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitOverviewsQueryServiceError";
+    this.cause = options?.cause;
+  }
+}
 
 export interface ICircuitOverviewsQueryService {
-  getAll(): Promise<CircuitOverviewsQueryServiceGetAllOutput>;
+  getAll(): Promise<Result<Array<CircuitOverview>, CircuitOverviewsQueryServiceError>>;
 }

--- a/src/domain/model/repository/ICircuitRepository.ts
+++ b/src/domain/model/repository/ICircuitRepository.ts
@@ -2,17 +2,17 @@ import type { Result } from "@/utils/result";
 import type { Circuit } from "../aggregate/circuit";
 import type { CircuitId } from "../valueObject/circuitId";
 
-export type CircuitRepositoryGetAllOutput = Result<Array<Circuit>>;
-
-export type CircuitRepositoryGetByIdOutput = Result<Circuit>;
-
-export type CircuitRepositorySaveOutput = Result<void>;
-
-export type CircuitRepositoryDeleteOutput = Result<void>;
+export class CircuitRepositoryError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitRepositoryError";
+    this.cause = options?.cause;
+  }
+}
 
 export interface ICircuitRepository {
-  getAll: () => Promise<CircuitRepositoryGetAllOutput>;
-  getById: (id: CircuitId) => Promise<CircuitRepositoryGetByIdOutput>;
-  save: (method: "ADD" | "UPDATE", circuit: Circuit) => Promise<CircuitRepositorySaveOutput>;
-  delete: (id: CircuitId) => Promise<CircuitRepositoryDeleteOutput>;
+  getAll: () => Promise<Result<Array<Circuit>, CircuitRepositoryError>>;
+  getById: (id: CircuitId) => Promise<Result<Circuit, CircuitRepositoryError>>;
+  save: (method: "ADD" | "UPDATE", circuit: Circuit) => Promise<Result<void, CircuitRepositoryError>>;
+  delete: (id: CircuitId) => Promise<Result<void, CircuitRepositoryError>>;
 }

--- a/src/domain/model/service/ICircuitEmulatorService.ts
+++ b/src/domain/model/service/ICircuitEmulatorService.ts
@@ -4,8 +4,16 @@ import type { CircuitNodeId } from "../valueObject/circuitNodeId";
 import type { InputRecord } from "../valueObject/inputRecord";
 import type { Phase } from "../valueObject/phase";
 
+export class CircuitEmulatorServiceError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitEmulatorServiceError";
+    this.cause = options?.cause;
+  }
+}
+
 export interface ICircuitEmulatorService {
-  setup(): Result<void>;
-  eval(entryInputs: InputRecord, phase: Phase): Result<void>;
-  getInfomationById(id: CircuitNodeId): Result<NodeInformation>;
+  setup(): Result<void, CircuitEmulatorServiceError>;
+  eval(entryInputs: InputRecord, phase: Phase): Result<void, CircuitEmulatorServiceError>;
+  getInfomationById(id: CircuitNodeId): Result<NodeInformation, CircuitEmulatorServiceError>;
 }

--- a/src/domain/model/service/ICircuitNode.ts
+++ b/src/domain/model/service/ICircuitNode.ts
@@ -5,9 +5,17 @@ import type { InputRecord } from "../valueObject/inputRecord";
 import type { Phase } from "../valueObject/phase";
 import type { Tick } from "../valueObject/tick";
 
+export class CircuitNodeError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitNodeError";
+    this.cause = options?.cause;
+  }
+}
+
 export interface ICircuitNode {
-  setup(order: ExecutionOrder): Result<void>;
-  init(): Result<void>;
-  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<boolean>;
+  setup(order: ExecutionOrder): Result<void, undefined>;
+  init(): Result<void, CircuitNodeError>;
+  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<boolean, CircuitNodeError>;
   getInformation(): NodeInformation;
 }

--- a/src/domain/model/service/ICircuitParserService.ts
+++ b/src/domain/model/service/ICircuitParserService.ts
@@ -3,7 +3,15 @@ import type { CircuitGraphData } from "../entity/circuitGraphData";
 import type { CircuitGuiData } from "../entity/circuitGuiData";
 import type { CircuitData } from "../valueObject/circuitData";
 
+export class CircuitParserServiceError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitParserServiceError";
+    this.cause = options?.cause;
+  }
+}
+
 export interface ICircuitParserService {
-  parseToGuiData(circuitData: CircuitData): Result<CircuitGuiData>;
-  parseToGraphData(circuitData: CircuitData): Result<CircuitGraphData>;
+  parseToGuiData(circuitData: CircuitData): Result<CircuitGuiData, CircuitParserServiceError>;
+  parseToGraphData(circuitData: CircuitData): Result<CircuitGraphData, CircuitParserServiceError>;
 }

--- a/src/domain/model/usecase/ICircuitEditorUsecase.ts
+++ b/src/domain/model/usecase/ICircuitEditorUsecase.ts
@@ -3,9 +3,17 @@ import type { Circuit } from "../aggregate/circuit";
 import type { CircuitData } from "../valueObject/circuitData";
 import type { CircuitId } from "../valueObject/circuitId";
 
+export class CircuitEditorUsecaseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitEditorUsecaseError";
+    this.cause = options?.cause;
+  }
+}
+
 export interface ICircuitEditorUsecase {
-  add(newCircuit: Circuit): Promise<Result<void>>;
-  save(newCircuit: Circuit): Promise<Result<void>>;
-  delete(id: CircuitId): Promise<Result<void>>;
-  isValidData(circuit: CircuitData): Result<void>;
+  add(newCircuit: Circuit): Promise<Result<void, CircuitEditorUsecaseError>>;
+  save(newCircuit: Circuit): Promise<Result<void, CircuitEditorUsecaseError>>;
+  delete(id: CircuitId): Promise<Result<void, CircuitEditorUsecaseError>>;
+  isValidData(circuit: CircuitData): Result<void, CircuitEditorUsecaseError>;
 }

--- a/src/domain/model/usecase/ICircuitParserUsecase.ts
+++ b/src/domain/model/usecase/ICircuitParserUsecase.ts
@@ -3,11 +3,15 @@ import type { CircuitGraphData } from "../entity/circuitGraphData";
 import type { CircuitGuiData } from "../entity/circuitGuiData";
 import type { CircuitData } from "../valueObject/circuitData";
 
-export type ICircuitParserUsecaseParseToGuiDataOutput = Result<Readonly<CircuitGuiData>>;
-
-export type ICircuitParserUsecaseParseToGraphDataOutput = Result<Readonly<CircuitGraphData>>;
+export class CircuitParserUsecaseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "CircuitParserUsecaseError";
+    this.cause = options?.cause;
+  }
+}
 
 export interface ICircuitParserUsecase {
-  parseToGuiData(textData: CircuitData): ICircuitParserUsecaseParseToGuiDataOutput;
-  parseToGraphData(textData: CircuitData): ICircuitParserUsecaseParseToGraphDataOutput;
+  parseToGuiData(textData: CircuitData): Result<CircuitGuiData, CircuitParserUsecaseError>;
+  parseToGraphData(textData: CircuitData): Result<CircuitGraphData, CircuitParserUsecaseError>;
 }

--- a/src/domain/model/usecase/IGenerateCircuitEmulatorServiceClientUsecase.ts
+++ b/src/domain/model/usecase/IGenerateCircuitEmulatorServiceClientUsecase.ts
@@ -2,8 +2,16 @@ import type { Result } from "@/utils/result";
 import type { CircuitGraphData } from "../entity/circuitGraphData";
 import type { ICircuitEmulatorService } from "../service/ICircuitEmulatorService";
 
-export type IGenerateCircuitEmulatorServiceClientUsecaseGenerateOutput = Readonly<Result<ICircuitEmulatorService>>;
+export class GenerateCircuitEmulatorServiceClientUsecaseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "GenerateCircuitEmulatorServiceClientUsecaseError";
+    this.cause = options?.cause;
+  }
+}
 
 export interface IGenerateCircuitEmulatorServiceClientUsecase {
-  generate(circuitGraphData: CircuitGraphData): IGenerateCircuitEmulatorServiceClientUsecaseGenerateOutput;
+  generate(
+    circuitGraphData: CircuitGraphData,
+  ): Result<ICircuitEmulatorService, GenerateCircuitEmulatorServiceClientUsecaseError>;
 }

--- a/src/domain/model/usecase/IGetCircuitDetailUsecase.ts
+++ b/src/domain/model/usecase/IGetCircuitDetailUsecase.ts
@@ -2,8 +2,14 @@ import type { Result } from "@/utils/result";
 import type { Circuit } from "../aggregate/circuit";
 import type { CircuitId } from "../valueObject/circuitId";
 
-export type IGetCircuitDetailUsecaseGetByIdOutput = Result<Readonly<Circuit>>;
+export class GetCircuitDetailUsecaseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "GetCircuitDetailUsecaseError";
+    this.cause = options?.cause;
+  }
+}
 
 export interface IGetCircuitDetailUsecase {
-  getById(id: CircuitId): Promise<IGetCircuitDetailUsecaseGetByIdOutput>;
+  getById(id: CircuitId): Promise<Result<Circuit, GetCircuitDetailUsecaseError>>;
 }

--- a/src/domain/model/usecase/IGetCircuitOverviewsUsecase.ts
+++ b/src/domain/model/usecase/IGetCircuitOverviewsUsecase.ts
@@ -1,8 +1,14 @@
 import type { Result } from "@/utils/result";
 import type { CircuitOverview } from "../entity/circuitOverview";
 
-export type IGetCircuitOverviewsUsecaseGetOverviewsOutput = Result<Array<Readonly<CircuitOverview>>>;
+export class GetCircuitOverviewsUsecaseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "GetCircuitOverviewsUsecaseError";
+    this.cause = options?.cause;
+  }
+}
 
 export interface IGetCircuitOverviewsUsecase {
-  getOverviews(): Promise<IGetCircuitOverviewsUsecaseGetOverviewsOutput>;
+  getOverviews(): Promise<Result<Array<CircuitOverview>, GetCircuitOverviewsUsecaseError>>;
 }

--- a/src/domain/model/valueObject/DateTime.ts
+++ b/src/domain/model/valueObject/DateTime.ts
@@ -1,5 +1,5 @@
-import { Attempt } from "@/utils/attempt";
 import type { Brand } from "@/utils/brand";
+import { ModelValidationError } from "../modelValidationError";
 
 const brandSymbol = Symbol("DateTime");
 
@@ -12,7 +12,8 @@ export namespace DateTime {
 
   export const fromString = (value: string): DateTime => {
     if (Number.isNaN(Date.parse(value))) {
-      throw new Attempt.ModelValidationError("DateTime", value);
+      // eslint-disable-next-line custom-rules/throw-only-in-try
+      throw new ModelValidationError("DateTime", value);
     }
 
     return new Date(value).toISOString() as DateTime;

--- a/src/domain/model/valueObject/circuitNodeType.ts
+++ b/src/domain/model/valueObject/circuitNodeType.ts
@@ -1,5 +1,5 @@
-import { Attempt } from "@/utils/attempt";
 import type { Brand } from "@/utils/brand";
+import { ModelValidationError } from "../modelValidationError";
 
 const brandSymbol = Symbol("CircuitNodeType");
 
@@ -10,7 +10,8 @@ export type CircuitNodeType = Brand<ICircuitNodeType, typeof brandSymbol>;
 export namespace CircuitNodeType {
   export const from = (value: string): CircuitNodeType => {
     if (!["ENTRY", "EXIT", "AND", "OR", "NOT", "JUNCTION"].includes(value)) {
-      throw new Attempt.ModelValidationError("CircuitNodeType", value);
+      // eslint-disable-next-line custom-rules/throw-only-in-try
+      throw new ModelValidationError("CircuitNodeType", value);
     }
 
     return value as CircuitNodeType;

--- a/src/domain/service/circuitEmulatorService/circuitNode.ts
+++ b/src/domain/service/circuitEmulatorService/circuitNode.ts
@@ -1,5 +1,5 @@
 import { NodeInformation } from "@/domain/model/entity/nodeInfomation.type";
-import type { ICircuitNode } from "@/domain/model/service/ICircuitNode";
+import { CircuitNodeError, type ICircuitNode } from "@/domain/model/service/ICircuitNode";
 import { CircuitNodeId } from "@/domain/model/valueObject/circuitNodeId";
 import { CircuitNodeInputId } from "@/domain/model/valueObject/circuitNodeInputId";
 import { CircuitNodeType } from "@/domain/model/valueObject/circuitNodeType";
@@ -9,29 +9,7 @@ import { ExecutionOrder } from "@/domain/model/valueObject/executionOrder";
 import type { InputRecord } from "@/domain/model/valueObject/inputRecord";
 import { Phase } from "@/domain/model/valueObject/phase";
 import { Tick } from "@/domain/model/valueObject/tick";
-import { Attempt } from "@/utils/attempt";
 import type { Result } from "@/utils/result";
-
-export class CircuitNodeFromError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "CircuitNodeFromError";
-  }
-}
-
-export class CircuitNodeInitError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "CircuitNodeInitError";
-  }
-}
-
-export class CircuitNodeEvalError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "CircuitNodeEvalError";
-  }
-}
 
 export abstract class CircuitNode implements ICircuitNode {
   protected readonly id: CircuitNodeId;
@@ -59,7 +37,7 @@ export abstract class CircuitNode implements ICircuitNode {
     type: CircuitNodeType,
     inputs: Array<CircuitNodeId>,
     outputs: Array<CircuitNodeId>,
-  ): Result<EntryNode | ExitNode | AndNode | OrNode | NotNode | JunctionNode> {
+  ): Result<EntryNode | ExitNode | AndNode | OrNode | NotNode | JunctionNode, CircuitNodeError> {
     switch (type) {
       case "ENTRY":
         return { ok: true, value: new EntryNode(id, inputs, outputs) };
@@ -74,11 +52,14 @@ export abstract class CircuitNode implements ICircuitNode {
       case "JUNCTION":
         return { ok: true, value: new JunctionNode(id, inputs, outputs) };
       default:
-        return { ok: false, error: new CircuitNodeFromError(`Invalid node type: ${type}`) };
+        return {
+          ok: false,
+          error: new CircuitNodeError(`Failed to generate circuit node. Received invalid node type: ${type}`),
+        };
     }
   }
 
-  setup(order: ExecutionOrder): Result<void> {
+  setup(order: ExecutionOrder): Result<void, undefined> {
     this.executionOrder = order;
     this.phase = Phase.from(0);
     this.tick = Tick.from(0);
@@ -86,39 +67,43 @@ export abstract class CircuitNode implements ICircuitNode {
     return { ok: true, value: undefined };
   }
 
-  init(): Result<void> {
-    return Attempt.proceed(
-      () => {
-        this.phase = Phase.from(1);
-        this.tick = Tick.from(0);
-        // biome-ignore lint/style/noNonNullAssertion: This is cared by the next if statement.
-        const initialHistory = this.history!.get(Phase.from(0));
-        if (!initialHistory) {
-          throw new Attempt.Abort("CircuitNode.init", "Failed to initialize node. This node might not be setup yet.", {
-            cause: new CircuitNodeInitError("Initial history for phase 0 not found."),
-          });
-        }
+  init(): Result<void, CircuitNodeError> {
+    this.phase = Phase.from(1);
+    this.tick = Tick.from(0);
 
-        this.history = EvalHistory.from(new Map([[Phase.from(0), initialHistory]]));
+    try {
+      // biome-ignore lint/style/noNonNullAssertion: This is cared by the next if statement.
+      const initialHistory = this.history!.get(Phase.from(0));
+      if (!initialHistory) {
+        throw new CircuitNodeError(
+          "Failed to initialize node because of missing initial history in phase 0. This node might not be setup yet.",
+        );
+      }
 
-        return { ok: true, value: undefined } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      this.history = EvalHistory.from(new Map([[Phase.from(0), initialHistory]]));
+    } catch (err: unknown) {
+      if (err instanceof CircuitNodeError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitNodeError("Unknown error occurred while initializing node.", { cause: err }),
+      };
+    }
+
+    return { ok: true, value: undefined };
   }
 
-  abstract eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult>;
+  abstract eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult, CircuitNodeError>;
   abstract getInformation(): NodeInformation;
 
-  protected saveOutput(phase: Phase, tick: Tick, output: EvalResult): Result<void> {
+  protected saveOutput(phase: Phase, tick: Tick, output: EvalResult): void {
     if (!this.history.has(phase)) {
       this.history.set(phase, new Map());
     }
     // biome-ignore lint/style/noNonNullAssertion: This is cared by the previous if statement.
     this.history.get(phase)!.set(tick, output);
-    return { ok: true, value: undefined };
   }
 }
 
@@ -128,32 +113,41 @@ class EntryNode extends CircuitNode {
     super(id, CircuitNodeType.from("ENTRY"), inputs, outputs);
   }
 
-  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult> {
-    return Attempt.proceed(
-      () => {
-        if (this.outputs.length !== 1) {
-          throw new Attempt.Abort("EntryNode.eval", "Failed to evaluate Entry node.", {
-            cause: new CircuitNodeEvalError(`ENTRY node "${this.id}" must have exactly one output.`),
-          });
-        }
+  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult, CircuitNodeError> {
+    try {
+      if (this.outputs.length !== 1) {
+        throw new CircuitNodeError(
+          `Failed to evaluate ENTRY node. ENTRY node ${this.id} must have exactly one output.`,
+        );
+      }
 
-        this.phase = phase;
-        this.tick = tick;
-        const result = {
-          CircuitNodeOutputId: this.outputs[0],
-          output: inputs[CircuitNodeInputId.from(this.id)] ?? false,
-        };
-        if (!this.history.has(phase)) {
-          this.history.set(phase, new Map());
-        }
-        this.saveOutput(phase, tick, result.output);
+      this.phase = phase;
+      this.tick = tick;
 
-        return { ok: true, value: result.output } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      const result = {
+        CircuitNodeOutputId: this.outputs[0],
+        output: inputs[CircuitNodeInputId.from(this.id)] ?? false,
+      };
+
+      if (!this.history.has(phase)) {
+        this.history.set(phase, new Map());
+      }
+
+      this.saveOutput(phase, tick, result.output);
+
+      return { ok: true, value: result.output };
+    } catch (err: unknown) {
+      if (err instanceof CircuitNodeError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitNodeError(`Unknown error occurred while evaluateing Entry node. id: ${this.id}`, {
+          cause: err,
+        }),
+      };
+    }
   }
 
   getInformation(): NodeInformation {
@@ -176,32 +170,39 @@ class ExitNode extends CircuitNode {
     super(id, CircuitNodeType.from("EXIT"), inputs, outputs);
   }
 
-  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult> {
-    return Attempt.proceed(
-      () => {
-        if (this.inputs.length !== 1 || this.outputs.length !== 0) {
-          throw new Attempt.Abort("ExitNode.eval", "Failed to evaluate Exit node.", {
-            cause: new CircuitNodeEvalError(`EXIT node "${this.id}" must have exactly one input.`),
-          });
-        }
+  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult, CircuitNodeError> {
+    try {
+      if (this.inputs.length !== 1 || this.outputs.length !== 0) {
+        throw new CircuitNodeError(`Failed to evaluate EXIT node. EXIT node "${this.id}" must have exactly one input.`);
+      }
 
-        this.phase = phase;
-        this.tick = tick;
-        const result = {
-          CircuitNodeOutputId: this.id,
-          output: inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false,
-        };
-        if (!this.history.has(phase)) {
-          this.history.set(phase, new Map());
-        }
-        this.saveOutput(phase, tick, result.output);
+      this.phase = phase;
+      this.tick = tick;
 
-        return { ok: true, value: result.output } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      const result = {
+        CircuitNodeOutputId: this.id,
+        output: inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false,
+      };
+
+      if (!this.history.has(phase)) {
+        this.history.set(phase, new Map());
+      }
+
+      this.saveOutput(phase, tick, result.output);
+
+      return { ok: true, value: result.output } as const;
+    } catch (err: unknown) {
+      if (err instanceof CircuitNodeError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitNodeError(`Unknown error occurred while evaluateing EXIT node. id: ${this.id}`, {
+          cause: err,
+        }),
+      };
+    }
   }
 
   getInformation(): NodeInformation {
@@ -224,31 +225,40 @@ class AndNode extends CircuitNode {
     super(id, CircuitNodeType.from("AND"), inputs, outputs);
   }
 
-  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult> {
-    return Attempt.proceed(
-      () => {
-        if (this.inputs.length !== 2 || this.outputs.length !== 1) {
-          throw new Attempt.Abort("AndNode.eval", "Failed to evaluate And node.", {
-            cause: new CircuitNodeEvalError(`AND node "${this.id}" must have exactly two inputs and one output`),
-          });
-        }
+  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult, CircuitNodeError> {
+    try {
+      if (this.inputs.length !== 2 || this.outputs.length !== 1) {
+        throw new CircuitNodeError(
+          `Failed to evaluate AND node. AND node "${this.id}" must have exactly two inputs and one output.`,
+        );
+      }
 
-        this.phase = phase;
-        this.tick = tick;
-        const a = inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false;
-        const b = inputs[CircuitNodeInputId.from(this.inputs[1])] ?? false;
-        const result = { CircuitNodeOutputId: this.outputs[0], output: a && b };
-        if (!this.history.has(phase)) {
-          this.history.set(phase, new Map());
-        }
-        this.saveOutput(phase, tick, result.output);
+      this.phase = phase;
+      this.tick = tick;
 
-        return { ok: true, value: result.output } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      const a = inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false;
+      const b = inputs[CircuitNodeInputId.from(this.inputs[1])] ?? false;
+      const result = { CircuitNodeOutputId: this.outputs[0], output: a && b };
+
+      if (!this.history.has(phase)) {
+        this.history.set(phase, new Map());
+      }
+
+      this.saveOutput(phase, tick, result.output);
+
+      return { ok: true, value: result.output } as const;
+    } catch (err: unknown) {
+      if (err instanceof CircuitNodeError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitNodeError(`Unknown error occurred while evaluateing AND node. id: ${this.id}`, {
+          cause: err,
+        }),
+      };
+    }
   }
 
   getInformation(): NodeInformation {
@@ -271,31 +281,39 @@ class OrNode extends CircuitNode {
     super(id, CircuitNodeType.from("OR"), inputs, outputs);
   }
 
-  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult> {
-    return Attempt.proceed(
-      () => {
-        if (this.inputs.length !== 2 || this.outputs.length !== 1) {
-          throw new Attempt.Abort("OrNode.eval", "Failed to evaluate Or node.", {
-            cause: new CircuitNodeEvalError(`OR node "${this.id}" must have exactly two inputs and one output`),
-          });
-        }
+  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult, CircuitNodeError> {
+    try {
+      if (this.inputs.length !== 2 || this.outputs.length !== 1) {
+        throw new CircuitNodeError(
+          `Failed to evaluate OR node. OR node "${this.id}" must have exactly two inputs and one output.`,
+        );
+      }
 
-        this.phase = phase;
-        this.tick = tick;
-        const a = inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false;
-        const b = inputs[CircuitNodeInputId.from(this.inputs[1])] ?? false;
-        const result = { CircuitNodeOutputId: this.outputs[0], output: a || b };
-        if (!this.history.has(phase)) {
-          this.history.set(phase, new Map());
-        }
-        this.saveOutput(phase, tick, result.output);
+      this.phase = phase;
+      this.tick = tick;
 
-        return { ok: true, value: result.output } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      const a = inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false;
+      const b = inputs[CircuitNodeInputId.from(this.inputs[1])] ?? false;
+      const result = { CircuitNodeOutputId: this.outputs[0], output: a || b };
+
+      if (!this.history.has(phase)) {
+        this.history.set(phase, new Map());
+      }
+      this.saveOutput(phase, tick, result.output);
+
+      return { ok: true, value: result.output } as const;
+    } catch (err: unknown) {
+      if (err instanceof CircuitNodeError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitNodeError(`Unknown error occurred while evaluateing OR node. id: ${this.id}`, {
+          cause: err,
+        }),
+      };
+    }
   }
 
   getInformation(): NodeInformation {
@@ -318,30 +336,39 @@ class NotNode extends CircuitNode {
     super(id, CircuitNodeType.from("NOT"), inputs, outputs);
   }
 
-  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult> {
-    return Attempt.proceed(
-      () => {
-        if (this.inputs.length !== 1 || this.outputs.length !== 1) {
-          throw new Attempt.Abort("NotNode.eval", "Failed to evaluate Not node.", {
-            cause: new CircuitNodeEvalError(`NOT node "${this.id}" must have exactly one input and one output`),
-          });
-        }
+  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult, CircuitNodeError> {
+    try {
+      if (this.inputs.length !== 1 || this.outputs.length !== 1) {
+        throw new CircuitNodeError(
+          `Failed to evaluate NOT node. NOT node "${this.id}" must have exactly one input and one output.`,
+        );
+      }
 
-        this.phase = phase;
-        this.tick = tick;
-        const input = inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false;
-        const result = { CircuitNodeOutputId: this.outputs[0], output: EvalResult.from(!input) };
-        if (!this.history.has(phase)) {
-          this.history.set(phase, new Map());
-        }
-        this.saveOutput(phase, tick, result.output);
+      this.phase = phase;
+      this.tick = tick;
 
-        return { ok: true, value: result.output } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      const input = inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false;
+      const result = { CircuitNodeOutputId: this.outputs[0], output: EvalResult.from(!input) };
+
+      if (!this.history.has(phase)) {
+        this.history.set(phase, new Map());
+      }
+
+      this.saveOutput(phase, tick, result.output);
+
+      return { ok: true, value: result.output } as const;
+    } catch (err: unknown) {
+      if (err instanceof CircuitNodeError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitNodeError(`Unknown error occurred while evaluateing NOT node. id: ${this.id}`, {
+          cause: err,
+        }),
+      };
+    }
   }
 
   getInformation(): NodeInformation {
@@ -364,36 +391,45 @@ class JunctionNode extends CircuitNode {
     super(id, CircuitNodeType.from("JUNCTION"), inputs, outputs);
   }
 
-  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult> {
-    return Attempt.proceed(
-      () => {
-        if (this.inputs.length !== 1 || this.outputs.length < 1) {
-          throw new Attempt.Abort("JunctionNode.eval", "Failed to evaluate Junction node.", {
-            cause: new CircuitNodeEvalError(`JUNCTION node "${this.id}" must have one input and at least one output`),
-          });
-        }
+  eval(inputs: InputRecord, phase: Phase, tick: Tick): Result<EvalResult, CircuitNodeError> {
+    try {
+      if (this.inputs.length !== 1 || this.outputs.length < 1) {
+        throw new CircuitNodeError(
+          `Failed to evaluate Junction node. JUNCTION node "${this.id}" must have one input and at least one output.`,
+        );
+      }
 
-        this.phase = phase;
-        this.tick = tick;
-        const output = inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false;
-        const result = this.outputs.map((CircuitNodeOutputId) => ({
-          CircuitNodeOutputId: CircuitNodeOutputId,
-          output: output,
-        }));
-        if (!this.history.has(phase)) {
-          this.history.set(phase, new Map());
-        }
-        result.forEach((result) => {
-          this.saveOutput(phase, tick, result.output);
-        });
+      this.phase = phase;
+      this.tick = tick;
 
-        // As all JUNCTION outputs are identical, it is allowed to return one of the multiple outputs.
-        return { ok: true, value: result[0].output } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      const output = inputs[CircuitNodeInputId.from(this.inputs[0])] ?? false;
+      const result = this.outputs.map((CircuitNodeOutputId) => ({
+        CircuitNodeOutputId: CircuitNodeOutputId,
+        output: output,
+      }));
+
+      if (!this.history.has(phase)) {
+        this.history.set(phase, new Map());
+      }
+      
+      result.forEach((result) => {
+        this.saveOutput(phase, tick, result.output);
+      });
+
+      // As all JUNCTION outputs are identical, it is allowed to return one of the multiple outputs.
+      return { ok: true, value: result[0].output } as const;
+    } catch (err: unknown) {
+      if (err instanceof CircuitNodeError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitNodeError(`Unknown error occurred while evaluateing JUNCTION node. id: ${this.id}`, {
+          cause: err,
+        }),
+      };
+    }
   }
 
   getInformation(): NodeInformation {

--- a/src/domain/service/circuitEmulatorService/circuitNode.ts
+++ b/src/domain/service/circuitEmulatorService/circuitNode.ts
@@ -51,11 +51,14 @@ export abstract class CircuitNode implements ICircuitNode {
         return { ok: true, value: new NotNode(id, inputs, outputs) };
       case "JUNCTION":
         return { ok: true, value: new JunctionNode(id, inputs, outputs) };
-      default:
+      default: {
+        const err = new CircuitNodeError(`Failed to generate circuit node. Received invalid node type: ${type}`);
+        console.error(err);
         return {
           ok: false,
-          error: new CircuitNodeError(`Failed to generate circuit node. Received invalid node type: ${type}`),
+          error: err,
         };
+      }
     }
   }
 
@@ -82,6 +85,7 @@ export abstract class CircuitNode implements ICircuitNode {
 
       this.history = EvalHistory.from(new Map([[Phase.from(0), initialHistory]]));
     } catch (err: unknown) {
+      console.error(err);
       if (err instanceof CircuitNodeError) {
         return { ok: false, error: err };
       }
@@ -137,6 +141,7 @@ class EntryNode extends CircuitNode {
 
       return { ok: true, value: result.output };
     } catch (err: unknown) {
+      console.error(err);
       if (err instanceof CircuitNodeError) {
         return { ok: false, error: err };
       }
@@ -192,6 +197,7 @@ class ExitNode extends CircuitNode {
 
       return { ok: true, value: result.output } as const;
     } catch (err: unknown) {
+      console.error(err);
       if (err instanceof CircuitNodeError) {
         return { ok: false, error: err };
       }
@@ -248,6 +254,7 @@ class AndNode extends CircuitNode {
 
       return { ok: true, value: result.output } as const;
     } catch (err: unknown) {
+      console.error(err);
       if (err instanceof CircuitNodeError) {
         return { ok: false, error: err };
       }
@@ -303,6 +310,7 @@ class OrNode extends CircuitNode {
 
       return { ok: true, value: result.output } as const;
     } catch (err: unknown) {
+      console.error(err);
       if (err instanceof CircuitNodeError) {
         return { ok: false, error: err };
       }
@@ -358,6 +366,7 @@ class NotNode extends CircuitNode {
 
       return { ok: true, value: result.output } as const;
     } catch (err: unknown) {
+      console.error(err);
       if (err instanceof CircuitNodeError) {
         return { ok: false, error: err };
       }
@@ -411,7 +420,7 @@ class JunctionNode extends CircuitNode {
       if (!this.history.has(phase)) {
         this.history.set(phase, new Map());
       }
-      
+
       result.forEach((result) => {
         this.saveOutput(phase, tick, result.output);
       });
@@ -419,6 +428,7 @@ class JunctionNode extends CircuitNode {
       // As all JUNCTION outputs are identical, it is allowed to return one of the multiple outputs.
       return { ok: true, value: result[0].output } as const;
     } catch (err: unknown) {
+      console.error(err);
       if (err instanceof CircuitNodeError) {
         return { ok: false, error: err };
       }

--- a/src/domain/service/circuitEmulatorService/index.ts
+++ b/src/domain/service/circuitEmulatorService/index.ts
@@ -1,5 +1,8 @@
 import type { NodeInformation } from "@/domain/model/entity/nodeInfomation.type";
-import type { ICircuitEmulatorService } from "@/domain/model/service/ICircuitEmulatorService";
+import {
+  CircuitEmulatorServiceError,
+  type ICircuitEmulatorService,
+} from "@/domain/model/service/ICircuitEmulatorService";
 import { CircuitNodeId } from "@/domain/model/valueObject/circuitNodeId";
 import { CircuitNodeInputId } from "@/domain/model/valueObject/circuitNodeInputId";
 import type { CircuitNodeType } from "@/domain/model/valueObject/circuitNodeType";
@@ -8,38 +11,9 @@ import { ExecutionOrder } from "@/domain/model/valueObject/executionOrder";
 import { InputRecord } from "@/domain/model/valueObject/inputRecord";
 import { Phase } from "@/domain/model/valueObject/phase";
 import { Tick } from "@/domain/model/valueObject/tick";
-import { Attempt } from "@/utils/attempt";
 import type { Result } from "@/utils/result";
 import type { CircuitGraphData } from "./../../model/entity/circuitGraphData";
 import { CircuitNode } from "./circuitNode";
-
-export class CircuitEmulatorServiceFromError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "CircuitEmulatorServiceFromError";
-  }
-}
-
-export class CircuitEmulatorServiceEvalError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "CircuitEmulatorServiceEvalError";
-  }
-}
-
-export class CircuitEmulatorServiceGetInfomationByIdError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "CircuitEmulatorServiceGetInfomationByIdError";
-  }
-}
-
-export class CircuitEmulatorServiceReferIncomingInputs extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "CircuitEmulatorServiceReferIncomingInputs";
-  }
-}
 
 export class CircuitEmulatorService implements ICircuitEmulatorService {
   private readonly nodes: CircuitNode[];
@@ -48,399 +22,395 @@ export class CircuitEmulatorService implements ICircuitEmulatorService {
     this.nodes = nodes;
   }
 
-  static from(circuitGraphData: CircuitGraphData): Result<CircuitEmulatorService> {
-    return Attempt.proceed(
-      () => {
-        const circuitNodes: CircuitNode[] = [];
+  static from(circuitGraphData: CircuitGraphData): Result<CircuitEmulatorService, CircuitEmulatorServiceError> {
+    const circuitNodes: CircuitNode[] = [];
 
-        const graphNodes: Set<{ nodeID: CircuitNodeId; type: CircuitNodeType }> = new Set();
-        // Use Set to store strings in “fromId->toId” format to eliminate duplicate edges.
-        const uniqueEdgeStrings: Set<string> = new Set();
+    const graphNodes: Set<{ nodeID: CircuitNodeId; type: CircuitNodeType }> = new Set();
+    // Use Set to store strings in “fromId->toId” format to eliminate duplicate edges.
+    const uniqueEdgeStrings: Set<string> = new Set();
 
-        for (const node of circuitGraphData) {
-          graphNodes.add({ nodeID: node.id, type: node.type });
-          for (const input of node.inputs) {
-            uniqueEdgeStrings.add(`${input}->${node.id}`);
-          }
-          for (const output of node.outputs) {
-            uniqueEdgeStrings.add(`${node.id}->${output}`);
-          }
+    for (const node of circuitGraphData) {
+      graphNodes.add({ nodeID: node.id, type: node.type });
+      for (const input of node.inputs) {
+        uniqueEdgeStrings.add(`${input}->${node.id}`);
+      }
+      for (const output of node.outputs) {
+        uniqueEdgeStrings.add(`${node.id}->${output}`);
+      }
+    }
+
+    const graphEdges: Map<CircuitNodeId, Array<{ from: CircuitNodeId; to: CircuitNodeId }>> = new Map();
+    for (const edgeString of Array.from(uniqueEdgeStrings)) {
+      const [from, to] = edgeString.split("->").map(CircuitNodeId.from);
+      if (from === undefined || to === undefined) continue;
+      const edge = { from: from as CircuitNodeId, to: to as CircuitNodeId };
+      // Initialize if there is no array corresponding to the "from" key
+      if (!graphEdges.has(from)) {
+        graphEdges.set(from, []);
+      }
+      // biome-ignore lint/style/noNonNullAssertion: As Map is initialized in the previous if statement, this is safe.
+      graphEdges.get(from)!.push(edge);
+    }
+
+    const allNodes = Array.from(graphNodes);
+    const allEdges = Array.from(graphEdges.values()).flat();
+
+    try {
+      // If I use "const node", VSCode recognize node as instance of CircuitNode for some reason. Therefore, I use destructuring to avoid this.
+      for (const { nodeID, type } of allNodes) {
+        const inputsToNode = allEdges.filter((edge) => edge.to === nodeID).map((edge) => edge.from);
+        const outputFromNode = allEdges.filter((edge) => edge.from === nodeID).map((edge) => edge.to);
+
+        const res = CircuitNode.from(nodeID, type, inputsToNode, outputFromNode);
+        if (!res.ok) {
+          throw new CircuitEmulatorServiceError(
+            `Failed to generate emulator service client. Couldn't generate circuit nodes. NodeId: ${nodeID}, Type: ${type}`,
+            {
+              cause: res.error,
+            },
+          );
         }
 
-        const graphEdges: Map<CircuitNodeId, Array<{ from: CircuitNodeId; to: CircuitNodeId }>> = new Map();
-        for (const edgeString of Array.from(uniqueEdgeStrings)) {
-          const [from, to] = edgeString.split("->").map(CircuitNodeId.from);
-          if (from === undefined || to === undefined) continue;
-          const edge = { from: from as CircuitNodeId, to: to as CircuitNodeId };
-          // Initialize if there is no array corresponding to the "from" key
-          if (!graphEdges.has(from)) {
-            graphEdges.set(from, []);
-          }
-          // biome-ignore lint/style/noNonNullAssertion: As Map is initialized in the previous if statement, this is safe.
-          graphEdges.get(from)!.push(edge);
-        }
+        circuitNodes.push(res.value);
+      }
 
-        const allNodes = Array.from(graphNodes);
-        const allEdges = Array.from(graphEdges.values()).flat();
+      // --- Define the execution orders of nodes --- //
+      // Perform topological sorting to the extent possible.
+      const removedNodeIds: Array<CircuitNodeId> = [];
+      const removedEages: {
+        from: CircuitNodeId;
+        to: CircuitNodeId;
+      }[] = [];
+      // As ENTORYs are always without dependencies, handle them first.
+      const entry = allNodes.filter((node) => node.type === "ENTRY");
+      removedNodeIds.push(...entry.map((node) => node.nodeID));
+      removedEages.push(...allEdges.filter((edge) => entry.some((node) => node.nodeID === edge.from)));
 
-        // If I use "const node", VSCode recognize node as instance of CircuitNode for some reason. Therefore, I use destructuring to avoid this.
-        for (const { nodeID, type } of allNodes) {
-          const inputsToNode = allEdges.filter((edge) => edge.to === nodeID).map((edge) => edge.from);
-          const outputFromNode = allEdges.filter((edge) => edge.from === nodeID).map((edge) => edge.to);
-
-          const res = CircuitNode.from(nodeID, type, inputsToNode, outputFromNode);
-          if (!res.ok) {
-            throw new Attempt.Abort(
-              "CircuitEmulatorService.from",
-              `Failed to generate circuit nodes. NodeId: ${nodeID}, Type: ${type}`,
-              {
-                cause: res.error,
-              },
-            );
-          }
-
-          circuitNodes.push(res.value);
-        }
-
-        // --- Define the execution orders of nodes --- //
-        // Perform topological sorting to the extent possible.
-        const removedNodeIds: Array<CircuitNodeId> = [];
-        const removedEages: {
-          from: CircuitNodeId;
-          to: CircuitNodeId;
-        }[] = [];
-        // As ENTORYs are always without dependencies, handle them first.
-        const entry = allNodes.filter((node) => node.type === "ENTRY");
-        removedNodeIds.push(...entry.map((node) => node.nodeID));
-        removedEages.push(...allEdges.filter((edge) => entry.some((node) => node.nodeID === edge.from)));
-
-        // Determines execution orders of remaining nodes.
-        // Topological sorting is performed to remove those that can be removed in order.
-        // If a loop is detected (breakFlag is true), the following operations are performed repeatedly until the execution order can be determined for all of them.
-        // The loop is broken by deleting the input (edge) of the node that is the endpoint of the edge cut by the topological sort, and then the topological sort is performed again.
-        while (removedNodeIds.length !== allNodes.length) {
-          while (true) {
-            let breakFlag = true;
-            for (const node of allNodes) {
-              const inputs = allEdges.filter((edge) => edge.to === node.nodeID && !removedEages.includes(edge));
-              if (removedNodeIds.includes(node.nodeID) || inputs.length !== 0) {
-                continue;
-              }
-              removedNodeIds.push(node.nodeID);
-              removedEages.push(...allEdges.filter((edge) => edge.from === node.nodeID));
-              breakFlag = false;
-            }
-            if (breakFlag) {
-              break;
-            }
-          }
-          const edgeLastRemoved = allEdges.filter((edge) => edge.from === removedNodeIds[removedNodeIds.length - 1]);
-          const edgeWillRemove = allEdges.filter((aEdge) => edgeLastRemoved.some((lEdge) => aEdge.to === lEdge.to));
-          removedEages.push(...edgeWillRemove);
-        }
-
-        // Assign execution order in the order of nodes removed.
-        removedNodeIds.forEach((nodeID, idx) => {
-          const target = circuitNodes.find((node) => node.getInformation().id === nodeID);
-          if (!target) {
-            throw new Attempt.Abort("CircuitEmulatorService.from", "Failed to assign execution orders.", {
-              cause: new CircuitEmulatorServiceFromError(`Node not found: ${nodeID}`),
-            });
-          }
-
-          target.setup(ExecutionOrder.from(idx + 1));
-        });
-
-        // Ascending order sorting by execution-order for ease of handling in other methods.
-        return {
-          ok: true,
-          value: new CircuitEmulatorService([
-            ...circuitNodes.sort((a, b) => a.getInformation().executionOrder - b.getInformation().executionOrder),
-          ]),
-        } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
-  }
-
-  setup(): Result<void> {
-    return Attempt.proceed(
-      () => {
-        // Initialize the output in phase 0 until all EvalResults are stabilized to make it executable.
-        const previousOutputs = new Map<CircuitNodeId, EvalResult>();
-        let tick = 0;
-        const tickLimit = this.nodes.length * 2;
-
+      // Determines execution orders of remaining nodes.
+      // Topological sorting is performed to remove those that can be removed in order.
+      // If a loop is detected (breakFlag is true), the following operations are performed repeatedly until the execution order can be determined for all of them.
+      // The loop is broken by deleting the input (edge) of the node that is the endpoint of the edge cut by the topological sort, and then the topological sort is performed again.
+      while (removedNodeIds.length !== allNodes.length) {
         while (true) {
-          let isAllOutputsStable = true;
-          for (const node of this.nodes) {
-            const { id, type, inputs } = node.getInformation();
-
-            switch (true) {
-              case type === "ENTRY": {
-                // As ENTRY does not have inputs by specification, it processes differently.
-                const entryInputRecord = InputRecord.from({});
-                for (const input of inputs) {
-                  // Give false to all inputs of ENTRY node by its Id.
-                  entryInputRecord[CircuitNodeInputId.from(input)] = EvalResult.from(false);
-                }
-
-                const currentOutput = node.eval(entryInputRecord, Phase.from(0), Tick.from(tick));
-                if (!currentOutput.ok) {
-                  throw new Attempt.Abort("CircuitEmulatorService.setup", "Failed to setup emulator service client.", {
-                    cause: currentOutput.error,
-                  });
-                }
-
-                previousOutputs.set(id, currentOutput.value);
-                break;
-              }
-              case tick === 0: {
-                // As referIncomingInputs cannot be used when tick is 0, this is handled as an exception.
-                const inputRecord = InputRecord.from({});
-
-                for (const input of inputs) {
-                  inputRecord[CircuitNodeInputId.from(input)] = EvalResult.from(previousOutputs.get(input) ?? false);
-                }
-
-                const currentOutput = node.eval(inputRecord, Phase.from(0), Tick.from(tick));
-                if (!currentOutput.ok) {
-                  throw new Attempt.Abort("CircuitEmulatorService.setup", "Failed to setup emulator service client.", {
-                    cause: currentOutput.error,
-                  });
-                }
-
-                previousOutputs.set(id, currentOutput.value);
-                break;
-              }
-              default: {
-                const incomingInputRecord = this.referIncomingInputs(id, Phase.from(0), Tick.from(tick));
-                if (!incomingInputRecord.ok) {
-                  throw new Attempt.Abort("CircuitEmulatorService.setup", "Failed to setup emulator service client.", {
-                    cause: incomingInputRecord.error,
-                  });
-                }
-
-                const currentOutput = node.eval(incomingInputRecord.value, Phase.from(0), Tick.from(tick));
-                if (!currentOutput.ok) {
-                  throw new Attempt.Abort("CircuitEmulatorService.setup", "Failed to setup emulator service client.", {
-                    cause: currentOutput.error,
-                  });
-                }
-
-                if (currentOutput.value !== previousOutputs.get(id)) {
-                  isAllOutputsStable = false;
-                }
-                previousOutputs.set(id, currentOutput.value);
-                break;
-              }
+          let breakFlag = true;
+          for (const node of allNodes) {
+            const inputs = allEdges.filter((edge) => edge.to === node.nodeID && !removedEages.includes(edge));
+            if (removedNodeIds.includes(node.nodeID) || inputs.length !== 0) {
+              continue;
             }
+            removedNodeIds.push(node.nodeID);
+            removedEages.push(...allEdges.filter((edge) => edge.from === node.nodeID));
+            breakFlag = false;
           }
-          if (tick > tickLimit || (isAllOutputsStable && tick !== 0)) {
+          if (breakFlag) {
             break;
           }
-          tick++;
+        }
+        const edgeLastRemoved = allEdges.filter((edge) => edge.from === removedNodeIds[removedNodeIds.length - 1]);
+        const edgeWillRemove = allEdges.filter((aEdge) => edgeLastRemoved.some((lEdge) => aEdge.to === lEdge.to));
+        removedEages.push(...edgeWillRemove);
+      }
+
+      // Assign execution order in the order of nodes removed.
+      removedNodeIds.forEach((nodeID, idx) => {
+        const target = circuitNodes.find((node) => node.getInformation().id === nodeID);
+        if (!target) {
+          throw new CircuitEmulatorServiceError(
+            `Failed to generate emulator service client. Couldn't assign execution orders. Node not found: ${nodeID}`,
+          );
         }
 
-        return { ok: true, value: undefined } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+        target.setup(ExecutionOrder.from(idx + 1));
+      });
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitEmulatorServiceError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitEmulatorServiceError("Unknown error occurred while generating circuit emulator service.", {
+          cause: err,
+        }),
+      };
+    }
+
+    // Ascending order sorting by execution-order for ease of handling in other methods.
+    return {
+      ok: true,
+      value: new CircuitEmulatorService([
+        ...circuitNodes.sort((a, b) => a.getInformation().executionOrder - b.getInformation().executionOrder),
+      ]),
+    };
   }
 
-  eval(entryInputs: InputRecord, phase: number): Result<void> {
-    return Attempt.proceed(
-      () => {
-        const previousOutputs = new Map<CircuitNodeId, EvalResult>();
-        let tick = 0;
-        const tickLimit = this.nodes.length * 2;
+  setup(): Result<void, CircuitEmulatorServiceError> {
+    // Initialize the output in phase 0 until all EvalResults are stabilized to make it executable.
+    const previousOutputs = new Map<CircuitNodeId, EvalResult>();
+    let tick = 0;
+    const tickLimit = this.nodes.length * 2;
 
-        while (true) {
-          let isAllOutputsStable = true;
-          for (const node of this.nodes) {
-            const { id, type } = node.getInformation();
-
-            switch (type) {
-              case "ENTRY": {
-                const currentOutput = node.eval(entryInputs, Phase.from(phase), Tick.from(tick));
-                if (!currentOutput.ok) {
-                  throw new Attempt.Abort("CircuitEmulatorService.eval", "Failed to evaluate node.", {
-                    cause: currentOutput.error,
-                  });
-                }
-
-                previousOutputs.set(id, currentOutput.value);
-                break;
-              }
-              default: {
-                const incomingInputRecord = this.referIncomingInputs(id, Phase.from(phase), Tick.from(tick));
-                if (!incomingInputRecord.ok) {
-                  throw new Attempt.Abort(
-                    "CircuitEmulatorService.eval",
-                    `Failed to refer incoming inputs of node. NodeId: ${id}`,
-                    {
-                      cause: incomingInputRecord.error,
-                    },
-                  );
-                }
-
-                const currentOutput = node.eval(incomingInputRecord.value, Phase.from(phase), Tick.from(tick));
-                if (!currentOutput.ok) {
-                  throw new Attempt.Abort("CircuitEmulatorService.eval", "Failed to evaluate node.", {
-                    cause: currentOutput.error,
-                  });
-                }
-
-                if (currentOutput.value !== previousOutputs.get(id)) {
-                  isAllOutputsStable = false;
-                }
-                previousOutputs.set(id, currentOutput.value);
-                break;
-              }
-            }
-          }
-          if (tick > tickLimit || isAllOutputsStable) {
-            break;
-          }
-          tick++;
-        }
-
-        return { ok: true, value: undefined } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
-  }
-
-  getInfomationById(id: CircuitNodeId): Result<NodeInformation> {
-    return Attempt.proceed(
-      () => {
-        const node = this.nodes.find((node) => node.getInformation().id === id)?.getInformation();
-        if (!node) {
-          throw new Attempt.Abort("CircuitEmulatorService.getInfomationById", "Failed to get node information.", {
-            cause: new CircuitEmulatorServiceGetInfomationByIdError(`Node not found: ${id}`),
-          });
-        }
-
-        return { ok: true, value: node } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
-  }
-
-  private referIncomingInputs(nodeID: CircuitNodeId, currentPhase: Phase, currentTick: Tick): Result<InputRecord> {
-    return Attempt.proceed(
-      () => {
-        const inputRecord = InputRecord.from({});
-
-        const isFirstTick = currentTick === 0;
-
-        const node = this.nodes.find((node) => node.getInformation().id === nodeID);
-        if (!node) {
-          throw new Attempt.Abort("CircuitEmulatorService.referIncomingInputs", "Failed to refer incoming inputs.", {
-            cause: new CircuitEmulatorServiceReferIncomingInputs(`Node not found: ${nodeID}`),
-          });
-        }
-
-        const { type, inputs } = node.getInformation();
-        if (type === "ENTRY") {
-          throw new Attempt.Abort("CircuitEmulatorService.referIncomingInputs", "Failed to refer incoming inputs.", {
-            cause: new CircuitEmulatorServiceReferIncomingInputs(
-              "Invalid usage. This method is not intended to be used for ENTRY nodes.",
-            ),
-          });
-        }
-
-        for (const input of inputs) {
-          const target = this.nodes.find((node) => node.getInformation().id === input);
-          const targetInfo = target?.getInformation();
-          if (!targetInfo) {
-            throw new Attempt.Abort("CircuitEmulatorService.referIncomingInputs", "Failed to refer incoming inputs.", {
-              cause: new CircuitEmulatorServiceReferIncomingInputs(`Target node not found. NodeId: ${input}`),
-            });
-          }
+    try {
+      while (true) {
+        let isAllOutputsStable = true;
+        for (const node of this.nodes) {
+          const { id, type, inputs } = node.getInformation();
 
           switch (true) {
-            case targetInfo.history.get(currentPhase)?.get(currentTick) === undefined && isFirstTick === true: {
-              const source = targetInfo.history.get(Phase.from(currentPhase - 1))?.entries();
-              if (!source) {
-                throw new Attempt.Abort(
-                  "CircuitEmulatorService.referIncomingInputs",
-                  "Failed to refer incoming inputs.",
-                  {
-                    cause: new CircuitEmulatorServiceReferIncomingInputs(
-                      `No history found for node: ${nodeID}, phase: ${currentPhase - 1}, tick: ${currentTick}`,
-                    ),
-                  },
-                );
+            case type === "ENTRY": {
+              // As ENTRY does not have inputs by specification, it processes differently.
+              const entryInputRecord = InputRecord.from({});
+              for (const input of inputs) {
+                // Give false to all inputs of ENTRY node by its Id.
+                entryInputRecord[CircuitNodeInputId.from(input)] = EvalResult.from(false);
               }
 
-              const output = Array.from(source).at(-1);
-              if (output === undefined) {
-                throw new Attempt.Abort(
-                  "CircuitEmulatorService.referIncomingInputs",
-                  "Failed to refer incoming inputs.",
-                  {
-                    cause: new CircuitEmulatorServiceReferIncomingInputs(
-                      `No output found for node: ${nodeID}, phase: ${currentPhase - 1}, tick: ${currentTick}`,
-                    ),
-                  },
-                );
+              const currentOutput = node.eval(entryInputRecord, Phase.from(0), Tick.from(tick));
+              if (!currentOutput.ok) {
+                throw new CircuitEmulatorServiceError("Failed to setup emulator service client.", {
+                  cause: currentOutput.error,
+                });
               }
 
-              inputRecord[CircuitNodeInputId.from(targetInfo.id)] = output[1];
+              previousOutputs.set(id, currentOutput.value);
               break;
             }
-            case targetInfo.history.get(currentPhase)?.get(currentTick) === undefined && isFirstTick === false: {
-              const output = targetInfo.history.get(currentPhase)?.get(Tick.from(currentTick - 1));
-              if (output === undefined) {
-                throw new Attempt.Abort(
-                  "CircuitEmulatorService.referIncomingInputs",
-                  "Failed to refer incoming inputs.",
-                  {
-                    cause: new CircuitEmulatorServiceReferIncomingInputs(
-                      `No output found for node: ${nodeID}, phase: ${currentPhase - 1}, tick: ${currentTick}`,
-                    ),
-                  },
-                );
+            case tick === 0: {
+              // As referIncomingInputs cannot be used when tick is 0, this is handled as an exception.
+              const inputRecord = InputRecord.from({});
+
+              for (const input of inputs) {
+                inputRecord[CircuitNodeInputId.from(input)] = EvalResult.from(previousOutputs.get(input) ?? false);
               }
 
-              inputRecord[CircuitNodeInputId.from(targetInfo.id)] = output;
+              const currentOutput = node.eval(inputRecord, Phase.from(0), Tick.from(tick));
+              if (!currentOutput.ok) {
+                throw new CircuitEmulatorServiceError("Failed to setup emulator service client.", {
+                  cause: currentOutput.error,
+                });
+              }
+
+              previousOutputs.set(id, currentOutput.value);
               break;
             }
-            // The above two cases are applied to nodes which receive inputs from a feedback loop.
             default: {
-              const output = targetInfo.history.get(currentPhase)?.get(currentTick);
-              if (output === undefined) {
-                throw new Attempt.Abort(
-                  "CircuitEmulatorService.referIncomingInputs",
-                  "Failed to refer incoming inputs.",
-                  {
-                    cause: new CircuitEmulatorServiceReferIncomingInputs(
-                      `No output found for node: ${nodeID}, phase: ${currentPhase - 1}, tick: ${currentTick}`,
-                    ),
-                  },
-                );
+              const incomingInputRecord = this.referIncomingInputs(id, Phase.from(0), Tick.from(tick));
+              if (!incomingInputRecord.ok) {
+                throw new CircuitEmulatorServiceError("Failed to setup emulator service client.", {
+                  cause: incomingInputRecord.error,
+                });
               }
 
-              inputRecord[CircuitNodeInputId.from(targetInfo.id)] = output;
+              const currentOutput = node.eval(incomingInputRecord.value, Phase.from(0), Tick.from(tick));
+              if (!currentOutput.ok) {
+                throw new CircuitEmulatorServiceError("Failed to setup emulator service client.", {
+                  cause: currentOutput.error,
+                });
+              }
+
+              if (currentOutput.value !== previousOutputs.get(id)) {
+                isAllOutputsStable = false;
+              }
+              previousOutputs.set(id, currentOutput.value);
               break;
             }
           }
         }
+        if (tick > tickLimit || (isAllOutputsStable && tick !== 0)) {
+          break;
+        }
+        tick++;
+      }
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitEmulatorServiceError) {
+        return { ok: false, error: err };
+      }
 
-        return { ok: true, value: inputRecord } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      return {
+        ok: false,
+        error: new CircuitEmulatorServiceError("Unknown error occurred while setting up emulator service client.", {
+          cause: err,
+        }),
+      };
+    }
+
+    return { ok: true, value: undefined };
+  }
+
+  eval(entryInputs: InputRecord, phase: number): Result<void, CircuitEmulatorServiceError> {
+    const previousOutputs = new Map<CircuitNodeId, EvalResult>();
+    let tick = 0;
+    const tickLimit = this.nodes.length * 2;
+
+    try {
+      while (true) {
+        let isAllOutputsStable = true;
+        for (const node of this.nodes) {
+          const { id, type } = node.getInformation();
+
+          switch (type) {
+            case "ENTRY": {
+              const currentOutput = node.eval(entryInputs, Phase.from(phase), Tick.from(tick));
+              if (!currentOutput.ok) {
+                throw new CircuitEmulatorServiceError(`Failed to evaluate circuit. Couldn't acquire output of ${id}.`, {
+                  cause: currentOutput.error,
+                });
+              }
+
+              previousOutputs.set(id, currentOutput.value);
+              break;
+            }
+            default: {
+              const incomingInputRecord = this.referIncomingInputs(id, Phase.from(phase), Tick.from(tick));
+              if (!incomingInputRecord.ok) {
+                throw new CircuitEmulatorServiceError(
+                  `Failed to evaluate circuit. Couldn't refer incoming inputs of ${id}.`,
+                  {
+                    cause: incomingInputRecord.error,
+                  },
+                );
+              }
+
+              const currentOutput = node.eval(incomingInputRecord.value, Phase.from(phase), Tick.from(tick));
+              if (!currentOutput.ok) {
+                throw new CircuitEmulatorServiceError(`Failed to evaluate circuit. Couldn't acquire output of ${id}.`, {
+                  cause: currentOutput.error,
+                });
+              }
+
+              if (currentOutput.value !== previousOutputs.get(id)) {
+                isAllOutputsStable = false;
+              }
+              previousOutputs.set(id, currentOutput.value);
+              break;
+            }
+          }
+        }
+        if (tick > tickLimit || isAllOutputsStable) {
+          break;
+        }
+        tick++;
+      }
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitEmulatorServiceError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitEmulatorServiceError("Unknown error occurred while evaluating circuit.", { cause: err }),
+      };
+    }
+
+    return { ok: true, value: undefined };
+  }
+
+  getInfomationById(id: CircuitNodeId): Result<NodeInformation, CircuitEmulatorServiceError> {
+    const node = this.nodes.find((node) => node.getInformation().id === id)?.getInformation();
+    if (!node) {
+      const err = new CircuitEmulatorServiceError(`Failed to get node information. Node not found: ${id}`);
+      console.error(err);
+      return {
+        ok: false,
+        error: err,
+      };
+    }
+
+    return { ok: true, value: node };
+  }
+
+  private referIncomingInputs(
+    nodeID: CircuitNodeId,
+    currentPhase: Phase,
+    currentTick: Tick,
+  ): Result<InputRecord, CircuitEmulatorServiceError> {
+    const inputRecord = InputRecord.from({});
+
+    const isFirstTick = currentTick === 0;
+
+    try {
+      const node = this.nodes.find((node) => node.getInformation().id === nodeID);
+      if (!node) {
+        throw new CircuitEmulatorServiceError(`Failed to refer incoming inputs. Node not found: ${nodeID}`);
+      }
+
+      const { type, inputs } = node.getInformation();
+      if (type === "ENTRY") {
+        throw new CircuitEmulatorServiceError(
+          "Failed to refer incoming inputs because of invalid usage This method is not intended to be used for ENTRY nodes.",
+        );
+      }
+
+      for (const input of inputs) {
+        const target = this.nodes.find((node) => node.getInformation().id === input);
+        const targetInfo = target?.getInformation();
+        if (!targetInfo) {
+          throw new CircuitEmulatorServiceError(
+            `Failed to refer incoming inputs. Target node not found. NodeId: ${input}`,
+          );
+        }
+
+        switch (true) {
+          case targetInfo.history.get(currentPhase)?.get(currentTick) === undefined && isFirstTick === true: {
+            const source = targetInfo.history.get(Phase.from(currentPhase - 1))?.entries();
+            if (!source) {
+              throw new CircuitEmulatorServiceError(
+                `Failed to refer incoming inputs. No history found for node: ${nodeID}, phase: ${currentPhase - 1}, tick: ${currentTick}`,
+              );
+            }
+
+            const output = Array.from(source).at(-1);
+            if (output === undefined) {
+              throw new CircuitEmulatorServiceError(
+                `Failed to refer incoming inputs. No output found for node: ${nodeID}, phase: ${currentPhase - 1}, tick: ${currentTick}`,
+              );
+            }
+
+            inputRecord[CircuitNodeInputId.from(targetInfo.id)] = output[1];
+            break;
+          }
+          case targetInfo.history.get(currentPhase)?.get(currentTick) === undefined && isFirstTick === false: {
+            const output = targetInfo.history.get(currentPhase)?.get(Tick.from(currentTick - 1));
+            if (output === undefined) {
+              throw new CircuitEmulatorServiceError(
+                `Failed to refer incoming inputs. No output found for node: ${nodeID}, phase: ${currentPhase - 1}, tick: ${currentTick}`,
+              );
+            }
+
+            inputRecord[CircuitNodeInputId.from(targetInfo.id)] = output;
+            break;
+          }
+          // The above two cases are applied to nodes which receive inputs from a feedback loop.
+          default: {
+            const output = targetInfo.history.get(currentPhase)?.get(currentTick);
+            if (output === undefined) {
+              throw new CircuitEmulatorServiceError(
+                `Failed to refer incoming inputs. No output found for node: ${nodeID}, phase: ${currentPhase - 1}, tick: ${currentTick}`,
+              );
+            }
+
+            inputRecord[CircuitNodeInputId.from(targetInfo.id)] = output;
+            break;
+          }
+        }
+      }
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitEmulatorServiceError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitEmulatorServiceError("Unknown error occurred while refering incoming inputs.", {
+          cause: err,
+        }),
+      };
+    }
+
+    return { ok: true, value: inputRecord };
   }
 }

--- a/src/domain/service/circuitParserService.ts
+++ b/src/domain/service/circuitParserService.ts
@@ -1,11 +1,11 @@
-import { Attempt } from "@/utils/attempt";
 import type { Result } from "@/utils/result";
 import { CircuitGraphData } from "../model/entity/circuitGraphData";
 import { CircuitGraphNode } from "../model/entity/circuitGraphNode";
 import { CircuitGuiData } from "../model/entity/circuitGuiData";
 import { CircuitGuiEdge } from "../model/entity/circuitGuiEdge";
 import { CircuitGuiNode } from "../model/entity/circuitGuiNode";
-import type { ICircuitParserService } from "../model/service/ICircuitParserService";
+import { ModelValidationError } from "../model/modelValidationError";
+import { CircuitParserServiceError, type ICircuitParserService } from "../model/service/ICircuitParserService";
 import type { CircuitData } from "../model/valueObject/circuitData";
 import type { CircuitEdgeId } from "../model/valueObject/circuitEdgeId";
 import { CircuitNodeId } from "../model/valueObject/circuitNodeId";
@@ -15,149 +15,179 @@ import { Coordinate } from "../model/valueObject/coordinate";
 import { Waypoint } from "../model/valueObject/waypoint";
 
 export class CircuitParserService implements ICircuitParserService {
-  parseToGuiData(circuitData: CircuitData): Result<CircuitGuiData> {
-    return Attempt.proceed(
-      () => {
-        const { nodes, edges } = circuitData;
+  parseToGuiData(circuitData: CircuitData): Result<CircuitGuiData, CircuitParserServiceError> {
+    try {
+      const { nodes, edges } = circuitData;
 
-        const guiNodes = nodes.map((node) => {
-          const { id, type, inputs: _inputs_, outputs: _outputs_, coordinate, size } = node;
+      const guiNodes = nodes.map((node) => {
+        const { id, type, inputs: _inputs_, outputs: _outputs_, coordinate, size } = node;
 
-          const inputs = _inputs_.map((input, idx) => ({
-            id: input,
-            coordinate: !["ENTRY", "EXIT", "JUNCTION"].includes(type)
-              ? Coordinate.from({
-                  x: coordinate.x - size.x / 2,
-                  y:
-                    _inputs_.length === 1
-                      ? coordinate.y
-                      : coordinate.y - size.y / 2 + (size.y / (_inputs_.length + 1)) * (1 + idx),
-                })
-              : Coordinate.from({
-                  x: coordinate.x,
-                  y: coordinate.y,
-                }),
-          }));
-          const outputs = _outputs_.map((output, idx) => ({
-            id: output,
-            coordinate: !["ENTRY", "EXIT", "JUNCTION"].includes(type)
-              ? Coordinate.from({
-                  x: coordinate.x + size.x / 2,
-                  y:
-                    _outputs_.length === 1
-                      ? coordinate.y
-                      : coordinate.y - size.y / 2 + (size.y / (_outputs_.length + 1)) * (1 + idx),
-                })
-              : Coordinate.from({
-                  x: coordinate.x,
-                  y: coordinate.y,
-                }),
-          }));
+        const inputs = _inputs_.map((input, idx) => ({
+          id: input,
+          coordinate: !["ENTRY", "EXIT", "JUNCTION"].includes(type)
+            ? Coordinate.from({
+                x: coordinate.x - size.x / 2,
+                y:
+                  _inputs_.length === 1
+                    ? coordinate.y
+                    : coordinate.y - size.y / 2 + (size.y / (_inputs_.length + 1)) * (1 + idx),
+              })
+            : Coordinate.from({
+                x: coordinate.x,
+                y: coordinate.y,
+              }),
+        }));
+        const outputs = _outputs_.map((output, idx) => ({
+          id: output,
+          coordinate: !["ENTRY", "EXIT", "JUNCTION"].includes(type)
+            ? Coordinate.from({
+                x: coordinate.x + size.x / 2,
+                y:
+                  _outputs_.length === 1
+                    ? coordinate.y
+                    : coordinate.y - size.y / 2 + (size.y / (_outputs_.length + 1)) * (1 + idx),
+              })
+            : Coordinate.from({
+                x: coordinate.x,
+                y: coordinate.y,
+              }),
+        }));
 
-          return CircuitGuiNode.from({
-            id,
-            type,
-            inputs,
-            outputs,
-            coordinate,
-            size,
-          });
+        return CircuitGuiNode.from({
+          id,
+          type,
+          inputs,
+          outputs,
+          coordinate,
+          size,
         });
+      });
 
-        const guiEdge = edges.map((edge) => {
-          const { id, from, to, waypoints: _waypoints_ } = edge;
+      const guiEdge = edges.map((edge) => {
+        const { id, from, to, waypoints: _waypoints_ } = edge;
 
-          const waypoints = Waypoint.waypointsToCoordinateArray(_waypoints_);
+        const waypoints = Waypoint.waypointsToCoordinateArray(_waypoints_);
 
-          return CircuitGuiEdge.from({
-            id,
-            from,
-            to,
-            waypoints,
-          });
+        return CircuitGuiEdge.from({
+          id,
+          from,
+          to,
+          waypoints,
         });
+      });
 
-        return { ok: true, value: CircuitGuiData.from({ nodes: guiNodes, edges: guiEdge }) } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      return { ok: true, value: CircuitGuiData.from({ nodes: guiNodes, edges: guiEdge }) } as const;
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof ModelValidationError) {
+        return {
+          ok: false,
+          error: new CircuitParserServiceError("Failed to parse circuit data to gui data. Invalid model provided.", {
+            cause: err,
+          }),
+        };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitParserServiceError("Unknown error occurred while parsing circuit data to gui data.", {
+          cause: err,
+        }),
+      };
+    }
   }
 
-  parseToGraphData(circuitData: CircuitData): Result<CircuitGraphData> {
-    return Attempt.proceed(
-      () => {
-        const nodes = new Map<
-          CircuitNodeId,
-          { type: CircuitNodeType; inputs: Array<CircuitNodePinId>; outputs: Array<CircuitNodePinId> }
-        >();
-        const edges = new Map<CircuitEdgeId, { from: CircuitNodePinId; to: CircuitNodePinId }>();
+  parseToGraphData(circuitData: CircuitData): Result<CircuitGraphData, CircuitParserServiceError> {
+    try {
+      const nodes = new Map<
+        CircuitNodeId,
+        { type: CircuitNodeType; inputs: Array<CircuitNodePinId>; outputs: Array<CircuitNodePinId> }
+      >();
+      const edges = new Map<CircuitEdgeId, { from: CircuitNodePinId; to: CircuitNodePinId }>();
 
-        for (const node of circuitData.nodes) {
-          const { id, type, inputs, outputs } = node;
-          nodes.set(id, { type, inputs, outputs });
-        }
-        for (const edge of circuitData.edges) {
-          const { id, from, to } = edge;
-          edges.set(id, { from, to });
-        }
+      for (const node of circuitData.nodes) {
+        const { id, type, inputs, outputs } = node;
+        nodes.set(id, { type, inputs, outputs });
+      }
+      for (const edge of circuitData.edges) {
+        const { id, from, to } = edge;
+        edges.set(id, { from, to });
+      }
 
-        const graphData = circuitData.nodes.map((node) => {
-          const connectedInEdge = Array.from(edges.entries())
-            .filter((edge) => node.inputs.includes(edge[1].to))
-            .map((edge) => edge[0]);
-          const connectedOutEdge = Array.from(edges.entries())
-            .filter((edge) => node.outputs.includes(edge[1].from))
-            .map((edge) => edge[0]);
+      const graphData = circuitData.nodes.map((node) => {
+        const connectedInEdge = Array.from(edges.entries())
+          .filter((edge) => node.inputs.includes(edge[1].to))
+          .map((edge) => edge[0]);
+        const connectedOutEdge = Array.from(edges.entries())
+          .filter((edge) => node.outputs.includes(edge[1].from))
+          .map((edge) => edge[0]);
 
-          const inputs = connectedInEdge.map((edgeId) => {
-            const targetEdge = edges.get(edgeId);
-            if (!targetEdge) {
-              throw new Attempt.Abort("CircuitParserService.parseToGraphData", `No target edge found: ${edgeId}`);
-            }
+        const inputs = connectedInEdge.map((edgeId) => {
+          const targetEdge = edges.get(edgeId);
+          if (!targetEdge) {
+            throw new CircuitParserServiceError(
+              `Failed to parse circuit data to graph data. No target edge for input found: ${edgeId}`,
+            );
+          }
 
-            const targetNode = Array.from(nodes.entries()).find((node) => node[1].outputs.includes(targetEdge.from));
-            if (!targetNode) {
-              throw new Attempt.Abort(
-                "CircuitParserService.parseToGraphData",
-                `No target node found: ${targetEdge.from}`,
-              );
-            }
+          const targetNode = Array.from(nodes.entries()).find((node) => node[1].outputs.includes(targetEdge.from));
+          if (!targetNode) {
+            throw new CircuitParserServiceError(
+              `Failed to parse circuit data to graph data. No target node for input found: ${targetEdge.from}`,
+            );
+          }
 
-            return CircuitNodeId.from(targetNode[0]);
-          });
-
-          const outputs = connectedOutEdge.map((edgeId) => {
-            const targetEdge = edges.get(edgeId);
-            if (!targetEdge) {
-              throw new Attempt.Abort("CircuitParserService.parseToGraphData", `No target edge found: ${edgeId}`);
-            }
-
-            const targetNode = Array.from(nodes.entries()).find((node) => node[1].inputs.includes(targetEdge.to));
-            if (!targetNode) {
-              throw new Attempt.Abort(
-                "CircuitParserService.parseToGraphData",
-                `No target node found: ${targetEdge.to}`,
-              );
-            }
-
-            return CircuitNodeId.from(targetNode[0]);
-          });
-
-          return CircuitGraphNode.from({
-            id: node.id,
-            type: node.type,
-            inputs: inputs.map(CircuitNodeId.from),
-            outputs: outputs.map(CircuitNodeId.from),
-          });
+          return CircuitNodeId.from(targetNode[0]);
         });
 
-        return { ok: true, value: CircuitGraphData.from(graphData) } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+        const outputs = connectedOutEdge.map((edgeId) => {
+          const targetEdge = edges.get(edgeId);
+          if (!targetEdge) {
+            throw new CircuitParserServiceError(
+              `Failed to parse circuit data to graph data. No target edge for output found: ${edgeId}`,
+            );
+          }
+
+          const targetNode = Array.from(nodes.entries()).find((node) => node[1].inputs.includes(targetEdge.to));
+          if (!targetNode) {
+            throw new CircuitParserServiceError(
+              `Failed to parse circuit data to graph data. No target node for output found: ${targetEdge.to}`,
+            );
+          }
+
+          return CircuitNodeId.from(targetNode[0]);
+        });
+
+        return CircuitGraphNode.from({
+          id: node.id,
+          type: node.type,
+          inputs: inputs.map(CircuitNodeId.from),
+          outputs: outputs.map(CircuitNodeId.from),
+        });
+      });
+
+      return { ok: true, value: CircuitGraphData.from(graphData) } as const;
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof ModelValidationError) {
+        return {
+          ok: false,
+          error: new CircuitParserServiceError("Failed to parse circuit data to graph data. Invalid model provided.", {
+            cause: err,
+          }),
+        };
+      }
+
+      if (err instanceof CircuitParserServiceError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitParserServiceError("Unknown error occurred while parsing circuit data to graph data.", {
+          cause: err,
+        }),
+      };
+    }
   }
 }

--- a/src/features/common/CircuitDiagram/edge/Edge.tsx
+++ b/src/features/common/CircuitDiagram/edge/Edge.tsx
@@ -48,7 +48,7 @@ export default function Edge({
     return (
       <>
         <SvgDefs>
-          {/** biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
+          {/** biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
           <SvgMarker id="arrow" markerWidth="5" markerHeight="5" refX="5" refY="2.5" orient="auto">
             <SvgPath d="M 0 0 L 5 2.5 L 0 5 z" fill="var(--color-circuit-state-high)" />
           </SvgMarker>

--- a/src/features/common/CircuitDiagram/edge/Edges.tsx
+++ b/src/features/common/CircuitDiagram/edge/Edges.tsx
@@ -39,11 +39,17 @@ export default function Edges({
   const outputMap = new Map<CircuitNodePinId, EvalResult>();
 
   data.nodes.forEach((node) => {
-    node.inputs.forEach((pin) => pinMap.set(pin.id, pin.coordinate));
-    node.outputs.forEach((pin) => pinMap.set(pin.id, pin.coordinate));
+    node.inputs.forEach((pin) => {
+      pinMap.set(pin.id, pin.coordinate);
+    });
+    node.outputs.forEach((pin) => {
+      pinMap.set(pin.id, pin.coordinate);
+    });
   });
 
-  data.edges.forEach((edge) => waypointsMap.set(edge.id, edge.waypoints));
+  data.edges.forEach((edge) => {
+    waypointsMap.set(edge.id, edge.waypoints);
+  });
 
   data?.nodes.forEach((node) => {
     node.inputs.forEach((pin) => {

--- a/src/features/common/CircuitDiagram/eventCaptureLayer/NodeDragInteractionLayer.tsx
+++ b/src/features/common/CircuitDiagram/eventCaptureLayer/NodeDragInteractionLayer.tsx
@@ -19,8 +19,7 @@ export default function NodeDragInteractionLayer({
 }: NodeDragInteractionLayerProps) {
   return (
     isActive && (
-      // biome-ignore lint/a11y/noStaticElementInteractions: No need for a11y support.
-      // biome-ignore lint/nursery/useUniqueElementIds: No need for unique id.
+      // biome-ignore lint/correctness/useUniqueElementIds: No need for unique id.
       <DragInteractionLayer
         isActive={isActive}
         id="node-drag-interaction-layer"

--- a/src/features/common/CircuitDiagram/eventCaptureLayer/NodePinDragInteractionLayer.tsx
+++ b/src/features/common/CircuitDiagram/eventCaptureLayer/NodePinDragInteractionLayer.tsx
@@ -24,8 +24,7 @@ export default function NodePinDragInteractionLayer({
   return (
     isActive && (
       <>
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: No need for a11y support. */}
-        {/* biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
+        {/* biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
         <DragInteractionLayer
           isActive={isActive}
           id="node-pin-drag-interaction-layer"

--- a/src/features/common/CircuitDiagram/eventCaptureLayer/WaypointDragInteractionLayer.tsx
+++ b/src/features/common/CircuitDiagram/eventCaptureLayer/WaypointDragInteractionLayer.tsx
@@ -19,8 +19,7 @@ export default function WaypointDragInteractionLayer({
 }: WaypointDragInteractionLayerProps) {
   return (
     isActive && (
-      // biome-ignore lint/a11y/noStaticElementInteractions: No need for a11y support.
-      // biome-ignore lint/nursery/useUniqueElementIds: No need for unique id.
+      // biome-ignore lint/correctness/useUniqueElementIds: No need for unique id.
       <DragInteractionLayer
         isActive={isActive}
         id="node-drag-interaction-layer"

--- a/src/features/common/CircuitDiagram/index.tsx
+++ b/src/features/common/CircuitDiagram/index.tsx
@@ -143,7 +143,7 @@ export default function CircuitDiagram({
       <SvgTitle>Circuit Diagram</SvgTitle>
 
       {showTouchableArea && (
-        // biome-ignore lint/nursery/useUniqueElementIds: No need for unique id.
+        // biome-ignore lint/correctness/useUniqueElementIds: No need for unique id.
         <SvgRect
           id="circuit-diagram-area"
           x={minX}
@@ -211,7 +211,7 @@ export default function CircuitDiagram({
 
           return (
             <>
-              {/** biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
+              {/** biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
               <DiagramUtilityMenuBackdrop
                 id="edge-utility-menu-backdrop"
                 viewBoxX={viewBox?.x}
@@ -259,7 +259,7 @@ export default function CircuitDiagram({
 
           return (
             <>
-              {/** biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
+              {/** biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
               <DiagramUtilityMenuBackdrop
                 id="node-utility-menu-backdrop"
                 viewBoxX={viewBox?.x}

--- a/src/features/common/CircuitDiagram/index.tsx
+++ b/src/features/common/CircuitDiagram/index.tsx
@@ -27,10 +27,10 @@ interface CircuitDiagramProps {
   svgRef?: React.RefObject<SVGSVGElement | null>;
   viewBox?: { x: number; y: number; w: number; h: number };
   isPanningRef?: React.RefObject<boolean>;
-  handleMouseDown?: (ev: React.MouseEvent) => void;
-  handleMouseMove?: (ev: React.MouseEvent) => void;
-  handleMouseUp?: () => void;
-  handleWheel?: (ev: React.WheelEvent) => void;
+  handleViewBoxMouseDown?: (ev: React.MouseEvent) => void;
+  handleViewBoxMouseMove?: (ev: React.MouseEvent) => void;
+  handleViewBoxMouseUp?: () => void;
+  handleViewBoxZoom?: (ev: React.WheelEvent) => void;
   preventBrowserZoom?: (ref: React.RefObject<SVGSVGElement | null>) => void;
   focusedElement?:
     | { kind: "node"; value: CircuitGuiNode }
@@ -85,10 +85,10 @@ export default function CircuitDiagram({
   svgRef,
   viewBox,
   isPanningRef,
-  handleMouseDown,
-  handleMouseMove,
-  handleMouseUp,
-  handleWheel,
+  handleViewBoxMouseDown,
+  handleViewBoxMouseMove,
+  handleViewBoxMouseUp,
+  handleViewBoxZoom,
   preventBrowserZoom,
   focusedElement,
   focusElement,
@@ -135,10 +135,10 @@ export default function CircuitDiagram({
       }
       style={{ background: "var(--color-circuit-diagram-bg)", cursor: isPanningRef?.current ? "grabbing" : "default" }}
       onContextMenu={disableContextMenu}
-      onWheel={handleWheel}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      onMouseUp={handleMouseUp}
+      onWheel={handleViewBoxZoom}
+      onMouseDown={handleViewBoxMouseDown}
+      onMouseMove={handleViewBoxMouseMove}
+      onMouseUp={handleViewBoxMouseUp}
     >
       <SvgTitle>Circuit Diagram</SvgTitle>
 

--- a/src/features/common/CircuitDiagram/node/Node.tsx
+++ b/src/features/common/CircuitDiagram/node/Node.tsx
@@ -96,7 +96,9 @@ export default function Node({
           openNodeUtilityMenu={isInFocus ? openNodeUtilityMenu : undefined}
         />
       );
-    default:
-      throw new Error(`Unknown node type: ${node.type}`);
+    default: {
+      console.log(`Unknown node type received. Type: ${node.type}`);
+      return null;
+    }
   }
 }

--- a/src/features/common/CircuitDiagram/node/logicGates/AndNode.tsx
+++ b/src/features/common/CircuitDiagram/node/logicGates/AndNode.tsx
@@ -1,4 +1,4 @@
-import { SvgCircle, SvgGroup, SvgPath } from "@/components/atoms/svg";
+import { SvgCircle, SvgGroup, SvgPath, SvgRect } from "@/components/atoms/svg";
 import type { CircuitGuiNode } from "@/domain/model/entity/circuitGuiNode";
 import type { CircuitNodePinId } from "@/domain/model/valueObject/circuitNodePinId";
 
@@ -72,9 +72,8 @@ export default function AndNode({
 
       {isInFocus && (
         <>
-          {/* biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: // biome-ignore lint/a11y/noStaticElementInteractions: No need for a11y support. */}
-          <rect
+          {/* biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
+          <SvgRect
             id="node-focused-frame"
             x={node.coordinate.x - node.size.x / 2 - 10}
             y={node.coordinate.y - node.size.y / 2 - 10}

--- a/src/features/common/CircuitDiagram/node/logicGates/EntryNode.tsx
+++ b/src/features/common/CircuitDiagram/node/logicGates/EntryNode.tsx
@@ -46,8 +46,7 @@ export default function EntryNode({
             onMouseDown={(ev) => handleNodePinMouseDown?.(ev, node.outputs[0].id, "from", "ADD")}
           />
 
-          {/** biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
-          {/** biome-ignore lint/a11y/noStaticElementInteractions: No need for a11y support.*/}
+          {/** biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
           <SvgCircle
             id="node-focused-frame"
             cx={node.coordinate.x}

--- a/src/features/common/CircuitDiagram/node/logicGates/ExitNode.tsx
+++ b/src/features/common/CircuitDiagram/node/logicGates/ExitNode.tsx
@@ -46,8 +46,7 @@ export default function ExitNode({
             onMouseDown={(ev) => handleNodePinMouseDown?.(ev, node.inputs[0].id, "to", "ADD")}
           />
 
-          {/** biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
-          {/** biome-ignore lint/a11y/noStaticElementInteractions: No need for a11y support.*/}
+          {/** biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
           <SvgCircle
             id="node-focused-frame"
             cx={node.coordinate.x}

--- a/src/features/common/CircuitDiagram/node/logicGates/JunctionNode.tsx
+++ b/src/features/common/CircuitDiagram/node/logicGates/JunctionNode.tsx
@@ -87,7 +87,7 @@ export default function JunctionNode({
             onMouseDown={(ev) => handleNodePinMouseDown?.(ev, node.outputs[0].id, "from", "ADD")}
           />
 
-          {/** biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
+          {/** biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
           <SvgCircle
             id="node-focused-frame"
             cx={node.coordinate.x}

--- a/src/features/common/CircuitDiagram/node/logicGates/NotNode.tsx
+++ b/src/features/common/CircuitDiagram/node/logicGates/NotNode.tsx
@@ -71,8 +71,7 @@ export default function NotNode({
 
       {isInFocus && (
         <>
-          {/* biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
-          {/** biome-ignore lint/a11y/noStaticElementInteractions: No need for a11y support. */}
+          {/* biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
           <SvgRect
             id="node-focused-frame"
             x={node.coordinate.x - node.size.x / 2 - 10}

--- a/src/features/common/CircuitDiagram/node/logicGates/OrNode.tsx
+++ b/src/features/common/CircuitDiagram/node/logicGates/OrNode.tsx
@@ -74,8 +74,7 @@ export default function OrNode({
 
       {isInFocus && (
         <>
-          {/* biome-ignore lint/nursery/useUniqueElementIds: No need for unique id. */}
-          {/** biome-ignore lint/a11y/noStaticElementInteractions: No need for a11y support. */}
+          {/* biome-ignore lint/correctness/useUniqueElementIds: No need for unique id. */}
           <SvgRect
             id="node-focused-frame"
             x={node.coordinate.x - node.size.x / 2 - 10}

--- a/src/features/routes/Circuit/CircuitEditor/CircuitEditorPageLayout.tsx
+++ b/src/features/routes/Circuit/CircuitEditor/CircuitEditorPageLayout.tsx
@@ -24,10 +24,10 @@ export default function CircuitEditorPageLayout() {
     guiData,
     viewBox,
     isPanningRef,
-    handleMouseDown,
-    handleMouseMove,
-    handleMouseUp,
-    handleWheel,
+    handleViewBoxMouseDown,
+    handleViewBoxMouseMove,
+    handleViewBoxMouseUp,
+    handleViewBoxZoom,
     preventBrowserZoom,
     save,
     deleteCircuit,
@@ -200,10 +200,10 @@ export default function CircuitEditorPageLayout() {
                             svgRef={svgRef}
                             viewBox={viewBox}
                             isPanningRef={isPanningRef}
-                            handleMouseDown={handleMouseDown}
-                            handleMouseMove={handleMouseMove}
-                            handleMouseUp={handleMouseUp}
-                            handleWheel={handleWheel}
+                            handleViewBoxMouseDown={handleViewBoxMouseDown}
+                            handleViewBoxMouseMove={handleViewBoxMouseMove}
+                            handleViewBoxMouseUp={handleViewBoxMouseUp}
+                            handleViewBoxZoom={handleViewBoxZoom}
                             preventBrowserZoom={preventBrowserZoom}
                             focusedElement={focusedElement}
                             focusElement={focusElement}

--- a/src/features/routes/Circuit/CircuitEditor/ElementSideBar.tsx
+++ b/src/features/routes/Circuit/CircuitEditor/ElementSideBar.tsx
@@ -77,7 +77,7 @@ export default function ElementSideBar({ viewBox, addCircuitNode }: ElementSideB
   };
 
   return (
-    // biome-ignore lint/nursery/useUniqueElementIds: No need for unique id.
+    // biome-ignore lint/correctness/useUniqueElementIds: No need for unique id.
     <Flex id="element-side-bar" direction="column" style={{ height: "100%", padding: 5 }}>
       <Typography>Logic gates</Typography>
       <Flex wrap="wrap" style={{ marginTop: 10 }}>

--- a/src/features/routes/Circuit/CircuitEditor/FormatSideBar.tsx
+++ b/src/features/routes/Circuit/CircuitEditor/FormatSideBar.tsx
@@ -18,7 +18,7 @@ interface FormatSideBarProps {
 
 export default function FormatSideBar({ data }: FormatSideBarProps) {
   return (
-    // biome-ignore lint/nursery/useUniqueElementIds: No need for unique id.
+    // biome-ignore lint/correctness/useUniqueElementIds: No need for unique id.
     <Flex id="format-side-bar" direction="column" style={{ height: "100%", padding: 5 }}>
       {!data ? (
         <Flex justifyContent="center" alignItems="center" grow={1}>

--- a/src/features/routes/Circuit/CircuitEmulation/CircuitEmulationPageLayout.tsx
+++ b/src/features/routes/Circuit/CircuitEmulation/CircuitEmulationPageLayout.tsx
@@ -13,6 +13,7 @@ import EvalMenu from "./EvalMenu";
 export default function CircuitEmulationPageLayout() {
   const {
     error,
+    uiState,
     overview,
     guiData,
     currentPhase,
@@ -20,7 +21,6 @@ export default function CircuitEmulationPageLayout() {
     outputs,
     updateEntryInputs,
     evalCircuit,
-    uiState,
     openToolBarMenu,
     closeToolBarMenu,
     changeActivityBarMenu,

--- a/src/features/routes/Circuit/CircuitView/CircuitViewPageLayout.tsx
+++ b/src/features/routes/Circuit/CircuitView/CircuitViewPageLayout.tsx
@@ -10,7 +10,7 @@ import CircuitDiagram from "../../../common/CircuitDiagram";
 import BaseCircuitPageLayout from "../common/BaseCircuitPageLayout";
 
 export default function CircuitViewPageLayout() {
-  const { error, overview, guiData, uiState, openToolBarMenu, closeToolBarMenu, changeActivityBarMenu } =
+  const { error, uiState, overview, guiData, openToolBarMenu, closeToolBarMenu, changeActivityBarMenu } =
     useCircuitViewPageHandlerContext();
 
   const isInError = error.failedToGetCircuitDetailError || error.failedToParseCircuitDataError;
@@ -63,63 +63,72 @@ export default function CircuitViewPageLayout() {
             error={isInError}
             onFailure={<Typography>Failed to load circuit data.</Typography>}
           >
-            {uiState.activityBarMenu.open === "infomation" ? (
-              <Flex direction="column" grow={1} style={{ height: "100%", width: "100%", padding: 20 }}>
-                <Typography size="superLarge">Infomation</Typography>
-                <Flex>
-                  <Flex direction="column" basis="60%" style={{ padding: 10 }}>
-                    <Typography size="huge">{overview?.title}</Typography>
-                    <Typography size="medium">{overview?.description}</Typography>
-                  </Flex>
-                  <Flex direction="column" basis="40%" style={{ padding: 10, minWidth: "450px" }}>
-                    <Table>
-                      <TableCaption>
-                        <Typography size="medium" style={{ paddingLeft: 20, textAlign: "start" }}>
-                          Property
-                        </Typography>
-                      </TableCaption>
-                      <TableRow>
-                        <TableCell style={{ padding: "8px 20px" }}>
-                          <Typography size="defaultPlus">ID</Typography>
-                        </TableCell>
-                        <TableCell style={{ padding: "8px 20px" }}>
-                          <Typography size="defaultPlus">{overview?.id}</Typography>
-                        </TableCell>
-                      </TableRow>
-                      <TableRow>
-                        <TableCell style={{ padding: "8px 20px" }}>
-                          <Typography size="defaultPlus">Created At</Typography>
-                        </TableCell>
-                        <TableCell style={{ padding: "8px 20px" }}>
-                          <Typography size="defaultPlus">{overview?.createdAt}</Typography>
-                        </TableCell>
-                      </TableRow>
-                      <TableRow>
-                        <TableCell style={{ padding: "8px 20px" }}>
-                          <Typography size="defaultPlus">Updated At</Typography>
-                        </TableCell>
-                        <TableCell style={{ padding: "8px 20px" }}>
-                          <Typography size="defaultPlus">{overview?.updatedAt}</Typography>
-                        </TableCell>
-                      </TableRow>
-                    </Table>
-                  </Flex>
-                </Flex>
-              </Flex>
-            ) : (
-              <Flex
-                direction="column"
-                alignItems="center"
-                justifyContent="center"
-                grow={1}
-                style={{ height: "100%", width: "100%", background: "var(--color-circuit-diagram-bg)" }}
-              >
-                <CircuitDiagram
-                  // biome-ignore lint/style/noNonNullAssertion: guiData is guaranteed to be present when isLoading is false
-                  data={guiData!}
-                />
-              </Flex>
-            )}
+            {(() => {
+              switch (uiState.activityBarMenu.open) {
+                case "infomation": {
+                  return (
+                    <Flex direction="column" grow={1} style={{ height: "100%", width: "100%", padding: 20 }}>
+                      <Typography size="superLarge">Infomation</Typography>
+                      <Flex>
+                        <Flex direction="column" basis="60%" style={{ padding: 10 }}>
+                          <Typography size="huge">{overview?.title}</Typography>
+                          <Typography size="medium">{overview?.description}</Typography>
+                        </Flex>
+                        <Flex direction="column" basis="40%" style={{ padding: 10, minWidth: "450px" }}>
+                          <Table>
+                            <TableCaption>
+                              <Typography size="medium" style={{ paddingLeft: 20, textAlign: "start" }}>
+                                Property
+                              </Typography>
+                            </TableCaption>
+                            <TableRow>
+                              <TableCell style={{ padding: "8px 20px" }}>
+                                <Typography size="defaultPlus">ID</Typography>
+                              </TableCell>
+                              <TableCell style={{ padding: "8px 20px" }}>
+                                <Typography size="defaultPlus">{overview?.id}</Typography>
+                              </TableCell>
+                            </TableRow>
+                            <TableRow>
+                              <TableCell style={{ padding: "8px 20px" }}>
+                                <Typography size="defaultPlus">Created At</Typography>
+                              </TableCell>
+                              <TableCell style={{ padding: "8px 20px" }}>
+                                <Typography size="defaultPlus">{overview?.createdAt}</Typography>
+                              </TableCell>
+                            </TableRow>
+                            <TableRow>
+                              <TableCell style={{ padding: "8px 20px" }}>
+                                <Typography size="defaultPlus">Updated At</Typography>
+                              </TableCell>
+                              <TableCell style={{ padding: "8px 20px" }}>
+                                <Typography size="defaultPlus">{overview?.updatedAt}</Typography>
+                              </TableCell>
+                            </TableRow>
+                          </Table>
+                        </Flex>
+                      </Flex>
+                    </Flex>
+                  );
+                }
+                case "circuitDiagram": {
+                  return (
+                    <Flex
+                      direction="column"
+                      alignItems="center"
+                      justifyContent="center"
+                      grow={1}
+                      style={{ height: "100%", width: "100%", background: "var(--color-circuit-diagram-bg)" }}
+                    >
+                      <CircuitDiagram
+                        // biome-ignore lint/style/noNonNullAssertion: guiData is guaranteed to be present when isLoading is false
+                        data={guiData!}
+                      />
+                    </Flex>
+                  );
+                }
+              }
+            })()}
           </Pending>
         </Flex>
       </BaseCircuitPageLayout>

--- a/src/handler/homePageHandler.ts
+++ b/src/handler/homePageHandler.ts
@@ -9,7 +9,7 @@ import {
   HomePageHandlerError,
   type HomePageUiStateModel,
   type IHomePageHandler,
-  initialHomePageErrorsValue,
+  initialHomePageError,
 } from "@/domain/model/handler/IHomePageHandler";
 import type { ICircuitEditorUsecase } from "@/domain/model/usecase/ICircuitEditorUsecase";
 import type { IGetCircuitOverviewsUsecase } from "@/domain/model/usecase/IGetCircuitOverviewsUsecase";
@@ -33,7 +33,7 @@ export const useHomePageHandler = ({
 }: HomePageHandlerDependencies): IHomePageHandler => {
   const router = useRouter();
 
-  const [error, setError] = usePartialState<HomePageErrorModel>(initialHomePageErrorsValue);
+  const [error, setError] = usePartialState<HomePageErrorModel>(initialHomePageError);
   const [uiState, setUiState] = usePartialState<HomePageUiStateModel>({
     tab: { open: "home" },
   });

--- a/src/handler/homePageHandler.ts
+++ b/src/handler/homePageHandler.ts
@@ -4,7 +4,13 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { Circuit } from "@/domain/model/aggregate/circuit";
 import type { CircuitOverview } from "@/domain/model/entity/circuitOverview";
-import { type HomePageError, homePageError, type IHomePageHandler } from "@/domain/model/handler/IHomePageHandler";
+import {
+  type HomePageErrorModel,
+  HomePageHandlerError,
+  type HomePageUiStateModel,
+  type IHomePageHandler,
+  initialHomePageErrorsValue,
+} from "@/domain/model/handler/IHomePageHandler";
 import type { ICircuitEditorUsecase } from "@/domain/model/usecase/ICircuitEditorUsecase";
 import type { IGetCircuitOverviewsUsecase } from "@/domain/model/usecase/IGetCircuitOverviewsUsecase";
 import { CircuitData } from "@/domain/model/valueObject/circuitData";
@@ -27,61 +33,58 @@ export const useHomePageHandler = ({
 }: HomePageHandlerDependencies): IHomePageHandler => {
   const router = useRouter();
 
-  const [error, setError] = usePartialState<HomePageError>(homePageError);
-  const [uiState, setUiState] = usePartialState<IHomePageHandler["uiState"]>({
+  const [error, setError] = usePartialState<HomePageErrorModel>(initialHomePageErrorsValue);
+  const [uiState, setUiState] = usePartialState<HomePageUiStateModel>({
     tab: { open: "home" },
   });
 
   const [circuitOverviews, setCircuitOverviews] = useState<Array<CircuitOverview> | undefined>(undefined);
 
   const fetch = useCallback(async (): Promise<void> => {
-    await Attempt.asyncProceed(
-      async () => {
-        const circuitOverviews = await getCircuitOverviewsUsecase.getOverviews();
-        if (!circuitOverviews.ok) {
-          throw new Attempt.Abort("homePageHandler.fetch", "Failed to get circuit overviews.", {
-            cause: circuitOverviews.error,
-          });
-        }
+    try {
+      const circuitOverviews = await getCircuitOverviewsUsecase.getOverviews();
+      if (!circuitOverviews.ok) {
+        throw new HomePageHandlerError("Failed to get circuit overviews.", {
+          cause: circuitOverviews.error,
+        });
+      }
 
-        setCircuitOverviews(circuitOverviews.value);
-      },
-      () => {
-        setError("failedToGetCircuitOverviewsError", true);
-      },
-    );
+      setCircuitOverviews(circuitOverviews.value);
+    } catch (err: unknown) {
+      console.error(err);
+      setError("failedToGetCircuitOverviewsError", true);
+    }
   }, [getCircuitOverviewsUsecase, setError]);
 
   const addNewCircuit = useCallback(
-    (kind: "empty") => {
-      Attempt.asyncProceed(
-        async () => {
-          switch (kind) {
-            case "empty": {
-              const newCircuitId = CircuitId.generate();
-              const res = await circuitEditorUsecase.add(
-                Circuit.from({
-                  id: newCircuitId,
-                  title: CircuitTitle.from(""),
-                  description: CircuitDescription.from(""),
-                  circuitData: CircuitData.from({ nodes: [], edges: [] }),
-                  createdAt: CreatedDateTime.fromDate(new Date()),
-                  updatedAt: UpdatedDateTime.fromDate(new Date()),
-                }),
-              );
-              if (!res.ok) {
-                throw new Attempt.Abort("homePageHandler.addNewCircuit", "Failed to add new circuit.", {
-                  cause: res.error,
-                });
-              }
-
-              router.push(`/circuit/${newCircuitId}`);
-              break;
+    async (kind: "empty") => {
+      try {
+        switch (kind) {
+          case "empty": {
+            const newCircuitId = CircuitId.generate();
+            const res = await circuitEditorUsecase.add(
+              Circuit.from({
+                id: newCircuitId,
+                title: CircuitTitle.from(""),
+                description: CircuitDescription.from(""),
+                circuitData: CircuitData.from({ nodes: [], edges: [] }),
+                createdAt: CreatedDateTime.fromDate(new Date()),
+                updatedAt: UpdatedDateTime.fromDate(new Date()),
+              }),
+            );
+            if (!res.ok) {
+              throw new Attempt.Abort("homePageHandler.addNewCircuit", "Failed to add new circuit.", {
+                cause: res.error,
+              });
             }
+
+            router.push(`/circuit/${newCircuitId}`);
+            break;
           }
-        },
-        () => {},
-      );
+        }
+      } catch (err: unknown) {
+        console.error(err);
+      }
     },
     [circuitEditorUsecase, router],
   );

--- a/src/infrastructure/queryService/circuitOverviewsQueryService.ts
+++ b/src/infrastructure/queryService/circuitOverviewsQueryService.ts
@@ -1,10 +1,11 @@
 import { CircuitOverview } from "@/domain/model/entity/circuitOverview";
-import type {
-  CircuitOverviewsQueryServiceGetAllOutput,
-  ICircuitOverviewsQueryService,
+import { ModelValidationError } from "@/domain/model/modelValidationError";
+import {
+  CircuitOverviewsQueryServiceError,
+  type ICircuitOverviewsQueryService,
 } from "@/domain/model/queryService/ICircuitOverviewsQueryService";
 import type { ICircuitRepository } from "@/domain/model/repository/ICircuitRepository";
-import { Attempt } from "@/utils/attempt";
+import type { Result } from "@/utils/result";
 
 interface CircuitOverviewsQueryServiceDependencies {
   circuitRepository: ICircuitRepository;
@@ -17,33 +18,52 @@ export class CircuitOverviewsQueryService implements ICircuitOverviewsQueryServi
     this.circuitRepository = circuitRepository;
   }
 
-  async getAll(): Promise<CircuitOverviewsQueryServiceGetAllOutput> {
-    return await Attempt.asyncProceed(
-      async () => {
-        const res = await this.circuitRepository.getAll();
-        if (!res.ok) {
-          throw new Attempt.Abort("CircuitOverviewsQueryService.getAll", "Failed to get circuits.", {
-            cause: res.error,
-          });
-        }
+  async getAll(): Promise<Result<Array<CircuitOverview>, CircuitOverviewsQueryServiceError>> {
+    try {
+      const res = await this.circuitRepository.getAll();
+      if (!res.ok) {
+        throw new CircuitOverviewsQueryServiceError("Failed to get circuit overviews.", {
+          cause: res.error,
+        });
+      }
 
-        const rawCircuits = res.value;
-        const circuitOverviews =
-          rawCircuits?.map((circuit) =>
-            CircuitOverview.from({
-              id: circuit.id,
-              title: circuit.title,
-              description: circuit.description,
-              createdAt: circuit.createdAt,
-              updatedAt: circuit.updatedAt,
-            }),
-          ) ?? [];
+      const rawCircuits = res.value;
+      const circuitOverviews =
+        rawCircuits?.map((circuit) =>
+          CircuitOverview.from({
+            id: circuit.id,
+            title: circuit.title,
+            description: circuit.description,
+            createdAt: circuit.createdAt,
+            updatedAt: circuit.updatedAt,
+          }),
+        ) ?? [];
 
-        return { ok: true, value: circuitOverviews } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      return { ok: true, value: circuitOverviews } as const;
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof ModelValidationError) {
+        return {
+          ok: false,
+          error: new CircuitOverviewsQueryServiceError(
+            "Failed to parse circuit data to gui data. Invalid model provided.",
+            {
+              cause: err,
+            },
+          ),
+        };
+      }
+
+      if (err instanceof CircuitOverviewsQueryServiceError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitOverviewsQueryServiceError("Unknown error occurred while getting circuit overviews.", {
+          cause: err,
+        }),
+      };
+    }
   }
 }

--- a/src/infrastructure/repository/circuitRepository.ts
+++ b/src/infrastructure/repository/circuitRepository.ts
@@ -1,3 +1,4 @@
+import { ModelValidationError } from "@/domain/model/modelValidationError";
 import { CircuitData } from "@/domain/model/valueObject/circuitData";
 import { CircuitDescription } from "@/domain/model/valueObject/circuitDescription";
 import { CircuitEdgeId } from "@/domain/model/valueObject/circuitEdgeId";
@@ -11,15 +12,9 @@ import { Coordinate } from "@/domain/model/valueObject/coordinate";
 import { CreatedDateTime } from "@/domain/model/valueObject/createdDateTime";
 import { UpdatedDateTime } from "@/domain/model/valueObject/updatedDateTime";
 import { Waypoint } from "@/domain/model/valueObject/waypoint";
-import { Attempt } from "@/utils/attempt";
+import type { Result } from "@/utils/result";
 import { Circuit } from "../../domain/model/aggregate/circuit";
-import type {
-  CircuitRepositoryDeleteOutput,
-  CircuitRepositoryGetAllOutput,
-  CircuitRepositoryGetByIdOutput,
-  CircuitRepositorySaveOutput,
-  ICircuitRepository,
-} from "../../domain/model/repository/ICircuitRepository";
+import { CircuitRepositoryError, type ICircuitRepository } from "../../domain/model/repository/ICircuitRepository";
 import type { ILocalStorage } from "../storage/localStorage";
 
 interface CircuitRepositoryDependencies {
@@ -33,184 +28,227 @@ export class CircuitRepository implements ICircuitRepository {
     this.localStorage = localStorage;
   }
 
-  async getAll(): Promise<CircuitRepositoryGetAllOutput> {
-    return await Attempt.asyncProceed(
-      async () => {
-        const res = await this.localStorage.get();
-        if (!res.ok) {
-          throw new Attempt.Abort("CircuitRepository.getAll", "Failed to get circuits.", { cause: res.error });
-        }
+  async getAll(): Promise<Result<Array<Circuit>, CircuitRepositoryError>> {
+    try {
+      const res = await this.localStorage.get();
+      if (!res.ok) {
+        throw new CircuitRepositoryError("Failed to get circuits.", { cause: res.error });
+      }
 
-        const rawCircuits = res.value;
-        const circuits =
-          rawCircuits?.map((circuit) =>
-            Circuit.from({
-              id: CircuitId.from(circuit.id),
-              title: CircuitTitle.from(circuit.title),
-              description: CircuitDescription.from(circuit.description),
-              circuitData: CircuitData.from({
-                nodes: circuit.circuitData.nodes.map((n) => ({
-                  id: CircuitNodeId.from(n.id),
-                  type: CircuitNodeType.from(n.type),
-                  inputs: n.inputs.map(CircuitNodePinId.from),
-                  outputs: n.outputs.map(CircuitNodePinId.from),
-                  coordinate: Coordinate.from(n.coordinate),
-                  size: CircuitNodeSize.from(n.size),
-                })),
-                edges: circuit.circuitData.edges.map((e) => ({
-                  id: CircuitEdgeId.from(e.id),
-                  from: CircuitNodePinId.from(e.from),
-                  to: CircuitNodePinId.from(e.to),
-                  waypoints: Waypoint.fromPrimitive(e.waypoints),
-                })),
-              }),
-              createdAt: CreatedDateTime.fromString(circuit.createdAt),
-              updatedAt: UpdatedDateTime.fromString(circuit.updatedAt),
+      const rawCircuits = res.value;
+      const circuits =
+        rawCircuits?.map((circuit) =>
+          Circuit.from({
+            id: CircuitId.from(circuit.id),
+            title: CircuitTitle.from(circuit.title),
+            description: CircuitDescription.from(circuit.description),
+            circuitData: CircuitData.from({
+              nodes: circuit.circuitData.nodes.map((n) => ({
+                id: CircuitNodeId.from(n.id),
+                type: CircuitNodeType.from(n.type),
+                inputs: n.inputs.map(CircuitNodePinId.from),
+                outputs: n.outputs.map(CircuitNodePinId.from),
+                coordinate: Coordinate.from(n.coordinate),
+                size: CircuitNodeSize.from(n.size),
+              })),
+              edges: circuit.circuitData.edges.map((e) => ({
+                id: CircuitEdgeId.from(e.id),
+                from: CircuitNodePinId.from(e.from),
+                to: CircuitNodePinId.from(e.to),
+                waypoints: Waypoint.fromPrimitive(e.waypoints),
+              })),
             }),
-          ) ?? [];
-        return { ok: true, value: circuits } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
-  }
-
-  async getById(id: CircuitId): Promise<CircuitRepositoryGetByIdOutput> {
-    return await Attempt.asyncProceed(
-      async () => {
-        const res = await this.localStorage.get();
-        if (!res.ok) {
-          throw new Attempt.Abort("CircuitRepository.getById", "Failed to get circuits.", { cause: res.error });
-        }
-
-        const rawCircuits = res.value;
-        const rawCircuit = rawCircuits?.find((c) => c.id === id);
-        if (rawCircuit === undefined) {
-          throw new Attempt.Abort(
-            "CircuitRepository.getById",
-            `Subject not found. You might specify a invalid Id. Id: ${id}`,
-          );
-        }
-
-        const circuit = Circuit.from({
-          id: CircuitId.from(rawCircuit.id),
-          title: CircuitTitle.from(rawCircuit.title),
-          description: CircuitDescription.from(rawCircuit.description),
-          circuitData: CircuitData.from({
-            nodes: rawCircuit.circuitData.nodes.map((n) => ({
-              id: CircuitNodeId.from(n.id),
-              type: CircuitNodeType.from(n.type),
-              inputs: n.inputs.map(CircuitNodePinId.from),
-              outputs: n.outputs.map(CircuitNodePinId.from),
-              coordinate: Coordinate.from(n.coordinate),
-              size: CircuitNodeSize.from(n.size),
-            })),
-            edges: rawCircuit.circuitData.edges.map((e) => ({
-              id: CircuitEdgeId.from(e.id),
-              from: CircuitNodePinId.from(e.from),
-              to: CircuitNodePinId.from(e.to),
-              waypoints: Waypoint.fromPrimitive(e.waypoints),
-            })),
+            createdAt: CreatedDateTime.fromString(circuit.createdAt),
+            updatedAt: UpdatedDateTime.fromString(circuit.updatedAt),
           }),
-          createdAt: CreatedDateTime.fromString(rawCircuit.createdAt),
-          updatedAt: UpdatedDateTime.fromString(rawCircuit.updatedAt),
-        });
+        ) ?? [];
+      return { ok: true, value: circuits };
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof ModelValidationError) {
+        return {
+          ok: false,
+          error: new CircuitRepositoryError("Failed to get circuits. Invalid model provided.", {
+            cause: err,
+          }),
+        };
+      }
 
-        return { ok: true, value: circuit } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      if (err instanceof CircuitRepositoryError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitRepositoryError("Unknown error occurred while getting circuits.", {
+          cause: err,
+        }),
+      };
+    }
   }
 
-  async save(method: "ADD" | "UPDATE", circuit: Circuit): Promise<CircuitRepositorySaveOutput> {
-    return await Attempt.asyncProceed(
-      async () => {
-        const get = await this.localStorage.get();
-        if (!get.ok) {
-          throw new Attempt.Abort(`CircuitRepository.save(${method})`, "Failed to get circuits.", { cause: get.error });
-        }
+  async getById(id: CircuitId): Promise<Result<Circuit, CircuitRepositoryError>> {
+    try {
+      const res = await this.localStorage.get();
+      if (!res.ok) {
+        throw new CircuitRepositoryError("Failed to get circuit.", { cause: res.error });
+      }
 
-        const current = get.value ?? [];
-        switch (method) {
-          case "ADD": {
-            const save = await this.localStorage.save([...current, circuit]);
-            if (!save.ok) {
-              throw new Attempt.Abort(`CircuitRepository.save(${method})`, "Failed to add circuits.", {
-                cause: save.error,
-              });
-            }
+      const rawCircuits = res.value;
+      const rawCircuit = rawCircuits?.find((c) => c.id === id);
+      if (rawCircuit === undefined) {
+        throw new CircuitRepositoryError(
+          `Failed to get circuit. Subject not found. You might specify a invalid Id. Id: ${id}`,
+        );
+      }
 
-            return { ok: true, value: undefined } as const;
-          }
-          case "UPDATE": {
-            if (current.length === 0) {
-              throw new Attempt.Abort(`CircuitRepository.save(${method})`, "No circuits saved.");
-            }
+      const circuit = Circuit.from({
+        id: CircuitId.from(rawCircuit.id),
+        title: CircuitTitle.from(rawCircuit.title),
+        description: CircuitDescription.from(rawCircuit.description),
+        circuitData: CircuitData.from({
+          nodes: rawCircuit.circuitData.nodes.map((n) => ({
+            id: CircuitNodeId.from(n.id),
+            type: CircuitNodeType.from(n.type),
+            inputs: n.inputs.map(CircuitNodePinId.from),
+            outputs: n.outputs.map(CircuitNodePinId.from),
+            coordinate: Coordinate.from(n.coordinate),
+            size: CircuitNodeSize.from(n.size),
+          })),
+          edges: rawCircuit.circuitData.edges.map((e) => ({
+            id: CircuitEdgeId.from(e.id),
+            from: CircuitNodePinId.from(e.from),
+            to: CircuitNodePinId.from(e.to),
+            waypoints: Waypoint.fromPrimitive(e.waypoints),
+          })),
+        }),
+        createdAt: CreatedDateTime.fromString(rawCircuit.createdAt),
+        updatedAt: UpdatedDateTime.fromString(rawCircuit.updatedAt),
+      });
 
-            const isExist = current.some((c) => c.id === circuit.id);
-            if (!isExist) {
-              throw new Attempt.Abort(
-                `CircuitRepository.save(${method})`,
-                `Subject not found. You might specify a invalid Id. Id: ${circuit.id}`,
-              );
-            }
+      return { ok: true, value: circuit };
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof ModelValidationError) {
+        return {
+          ok: false,
+          error: new CircuitRepositoryError("Failed to get circuit. Invalid model provided.", {
+            cause: err,
+          }),
+        };
+      }
 
-            const updated = current.map((c) => (c.id === circuit.id ? circuit : c));
-            const save = await this.localStorage.save(updated);
-            if (!save.ok) {
-              throw new Attempt.Abort(`CircuitRepository.save(${method})`, "Failed to save circuits.", {
-                cause: save.error,
-              });
-            }
+      if (err instanceof CircuitRepositoryError) {
+        return { ok: false, error: err };
+      }
 
-            return { ok: true, value: undefined } as const;
-          }
-          default: {
-            throw new Attempt.Abort(`CircuitRepository.save(${method})`, "Invalid method.");
-          }
-        }
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      return {
+        ok: false,
+        error: new CircuitRepositoryError("Unknown error occurred while getting circuit.", {
+          cause: err,
+        }),
+      };
+    }
   }
 
-  async delete(id: CircuitId): Promise<CircuitRepositoryDeleteOutput> {
-    return await Attempt.asyncProceed(
-      async () => {
-        const get = await this.localStorage.get();
-        if (!get.ok) {
-          throw new Attempt.Abort("CircuitRepository.delete", "Failed to get circuits.", { cause: get.error });
-        }
+  async save(method: "ADD" | "UPDATE", circuit: Circuit): Promise<Result<void, CircuitRepositoryError>> {
+    try {
+      const get = await this.localStorage.get();
+      if (!get.ok) {
+        throw new CircuitRepositoryError("Failed to save circuit. Couldn't get circuits.", { cause: get.error });
+      }
 
-        const current = get.value ?? [];
-        if (current.length === 0) {
-          throw new Attempt.Abort("CircuitRepository.delete", "No circuits saved.");
-        }
+      const current = get.value ?? [];
+      switch (method) {
+        case "ADD": {
+          const save = await this.localStorage.save([...current, circuit]);
+          if (!save.ok) {
+            throw new CircuitRepositoryError("Failed to add circuits.", {
+              cause: save.error,
+            });
+          }
 
-        const isExist = current.some((c) => c.id === id);
-        if (!isExist) {
-          throw new Attempt.Abort(
-            "CircuitRepository.delete",
-            `Subject not found. You might specify a invalid Id. Id: ${id}`,
-          );
+          return { ok: true, value: undefined } as const;
         }
+        case "UPDATE": {
+          if (current.length === 0) {
+            throw new CircuitRepositoryError("Failed to update circuit. No circuits saved.");
+          }
 
-        const updated = current.filter((c) => c.id !== id);
-        const save = await this.localStorage.save(updated);
-        if (!save.ok) {
-          throw new Attempt.Abort("CircuitRepository.delete", "Failed to save circuits.", { cause: save.error });
+          const isExist = current.some((c) => c.id === circuit.id);
+          if (!isExist) {
+            throw new CircuitRepositoryError(
+              `Failed to update circuit. Subject not found. You might specify a invalid Id. Id: ${circuit.id}`,
+            );
+          }
+
+          const updated = current.map((c) => (c.id === circuit.id ? circuit : c));
+          const save = await this.localStorage.save(updated);
+          if (!save.ok) {
+            throw new CircuitRepositoryError("Failed to update circuit.", {
+              cause: save.error,
+            });
+          }
+
+          return { ok: true, value: undefined } as const;
         }
+        default: {
+          throw new CircuitRepositoryError("Invalid method was specified.");
+        }
+      }
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitRepositoryError) {
+        return { ok: false, error: err };
+      }
 
-        return { ok: true, value: undefined } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      return {
+        ok: false,
+        error: new CircuitRepositoryError(`Unknown error occurred while ${method}ing circuit.`, {
+          cause: err,
+        }),
+      };
+    }
+  }
+
+  async delete(id: CircuitId): Promise<Result<void, CircuitRepositoryError>> {
+    try {
+      const get = await this.localStorage.get();
+      if (!get.ok) {
+        throw new CircuitRepositoryError("Failed to delete circuit. Couldn't get circuits.", { cause: get.error });
+      }
+
+      const current = get.value ?? [];
+      if (current.length === 0) {
+        throw new CircuitRepositoryError("Failed to delete circuit. No circuits saved.");
+      }
+
+      const isExist = current.some((c) => c.id === id);
+      if (!isExist) {
+        throw new CircuitRepositoryError(
+          `Failed to delete circuit. Subject not found. You might specify a invalid Id. Id: ${id}`,
+        );
+      }
+
+      const updated = current.filter((c) => c.id !== id);
+      const save = await this.localStorage.save(updated);
+      if (!save.ok) {
+        throw new CircuitRepositoryError("Failed to save circuits.", { cause: save.error });
+      }
+
+      return { ok: true, value: undefined };
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitRepositoryError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitRepositoryError("Unknown error occurred while deleting circuit.", {
+          cause: err,
+        }),
+      };
+    }
   }
 }

--- a/src/usecase/circuitEditorUsecase.ts
+++ b/src/usecase/circuitEditorUsecase.ts
@@ -1,25 +1,16 @@
 import type { Circuit } from "@/domain/model/aggregate/circuit";
 import type { ICircuitRepository } from "@/domain/model/repository/ICircuitRepository";
 import type { ICircuitParserService } from "@/domain/model/service/ICircuitParserService";
-import type { ICircuitEditorUsecase } from "@/domain/model/usecase/ICircuitEditorUsecase";
+import { CircuitEditorUsecaseError, type ICircuitEditorUsecase } from "@/domain/model/usecase/ICircuitEditorUsecase";
 import type { CircuitData } from "@/domain/model/valueObject/circuitData";
 import type { CircuitId } from "@/domain/model/valueObject/circuitId";
 import type { CircuitNodeId } from "@/domain/model/valueObject/circuitNodeId";
 import type { CircuitNodePinId } from "@/domain/model/valueObject/circuitNodePinId";
-import { Attempt } from "@/utils/attempt";
 import type { Result } from "@/utils/result";
 
 interface CircuitEditorUsecaseDependencies {
   circuitRepository: ICircuitRepository;
   circuitParserService: ICircuitParserService;
-}
-
-export class CircuitEditorUsecaseGenerateNewCircuitDataError extends Error {
-  constructor(message: string, options?: { cause: unknown }) {
-    super(message);
-    this.cause = options?.cause;
-    this.name = "CircuitEditorUsecaseGenerateNewCircuitDataError";
-  }
 }
 
 export class CircuitEditorUsecase implements ICircuitEditorUsecase {
@@ -29,64 +20,76 @@ export class CircuitEditorUsecase implements ICircuitEditorUsecase {
     this.circuitRepository = circuitRepository;
   }
 
-  async add(newCircuit: Circuit): Promise<Result<void>> {
-    return await Attempt.asyncProceed(
-      async () => {
-        const res = await this.circuitRepository.save("ADD", newCircuit);
-        if (!res.ok) {
-          throw new Attempt.Abort("CircuitEditorUsecase.add", "Failed to add circuit.", { cause: res.error });
-        }
+  async add(newCircuit: Circuit): Promise<Result<void, CircuitEditorUsecaseError>> {
+    try {
+      const res = await this.circuitRepository.save("ADD", newCircuit);
+      if (!res.ok) {
+        throw new CircuitEditorUsecaseError("Failed to add circuit.", { cause: res.error });
+      }
 
-        return { ok: true, value: undefined } as const;
-      },
-      (err: unknown) => {
-        return {
-          ok: false,
-          error: err,
-        } as const;
-      },
-    );
+      return { ok: true, value: undefined } as const;
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitEditorUsecaseError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitEditorUsecaseError("Unknown error occurred while adding circuit.", {
+          cause: err,
+        }),
+      };
+    }
   }
 
-  async save(newCircuit: Circuit): Promise<Result<void>> {
-    return await Attempt.asyncProceed(
-      async () => {
-        const res = await this.circuitRepository.save("UPDATE", newCircuit);
-        if (!res.ok) {
-          throw new Attempt.Abort("CircuitEditorUsecase.save", "Failed to save circuit.", { cause: res.error });
-        }
+  async save(newCircuit: Circuit): Promise<Result<void, CircuitEditorUsecaseError>> {
+    try {
+      const res = await this.circuitRepository.save("UPDATE", newCircuit);
+      if (!res.ok) {
+        throw new CircuitEditorUsecaseError("Failed to save circuit.", { cause: res.error });
+      }
 
-        return { ok: true, value: undefined } as const;
-      },
-      (err: unknown) => {
-        return {
-          ok: false,
-          error: err,
-        } as const;
-      },
-    );
+      return { ok: true, value: undefined } as const;
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitEditorUsecaseError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitEditorUsecaseError("Unknown error occurred while saving circuit.", {
+          cause: err,
+        }),
+      };
+    }
   }
 
-  async delete(id: CircuitId): Promise<Result<void>> {
-    return await Attempt.asyncProceed(
-      async () => {
-        const res = await this.circuitRepository.delete(id);
-        if (!res.ok) {
-          throw new Attempt.Abort("CircuitEditorUsecase.delete", "Failed to delete circuit.", { cause: res.error });
-        }
+  async delete(id: CircuitId): Promise<Result<void, CircuitEditorUsecaseError>> {
+    try {
+      const res = await this.circuitRepository.delete(id);
+      if (!res.ok) {
+        throw new CircuitEditorUsecaseError("Failed to delete circuit.", { cause: res.error });
+      }
 
-        return { ok: true, value: undefined } as const;
-      },
-      (err: unknown) => {
-        return {
-          ok: false,
-          error: err,
-        } as const;
-      },
-    );
+      return { ok: true, value: undefined } as const;
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitEditorUsecaseError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitEditorUsecaseError("Unknown error occurred while deleting circuit.", {
+          cause: err,
+        }),
+      };
+    }
   }
 
-  isValidData(circuit: CircuitData): Result<void> {
+  isValidData(circuit: CircuitData): Result<void, CircuitEditorUsecaseError> {
     const flags = {
       foundDuplicatedNodeId: false,
       foundDuplicatedEdgeId: false,
@@ -103,80 +106,78 @@ export class CircuitEditorUsecase implements ICircuitEditorUsecase {
 
     const { nodes, edges } = circuit;
 
-    return Attempt.proceed(
-      () => {
-        for (const node of nodes) {
-          if (nodeIds.has(node.id)) {
-            flags.foundDuplicatedNodeId = true;
-          }
-          nodeIds.add(node.id);
+    try {
+      for (const node of nodes) {
+        if (nodeIds.has(node.id)) {
+          flags.foundDuplicatedNodeId = true;
+        }
+        nodeIds.add(node.id);
 
-          for (const inputPin of node.inputs) {
-            if (nodePinIds.has(inputPin)) {
-              flags.foundDuplicatedNodePinId = true;
-            }
-            nodePinIds.add(inputPin);
-            nodePinDict.set(inputPin, [node.id, "input"]);
+        for (const inputPin of node.inputs) {
+          if (nodePinIds.has(inputPin)) {
+            flags.foundDuplicatedNodePinId = true;
           }
-
-          for (const outputPin of node.outputs) {
-            if (nodePinIds.has(outputPin)) {
-              flags.foundDuplicatedNodePinId = true;
-            }
-            nodePinIds.add(outputPin);
-            nodePinDict.set(outputPin, [node.id, "output"]);
-          }
+          nodePinIds.add(inputPin);
+          nodePinDict.set(inputPin, [node.id, "input"]);
         }
 
-        for (const edge of edges) {
-          if (edgeIds.has(edge.id)) {
-            flags.foundDuplicatedEdgeId = true;
+        for (const outputPin of node.outputs) {
+          if (nodePinIds.has(outputPin)) {
+            flags.foundDuplicatedNodePinId = true;
           }
-          edgeIds.add(edge.id);
+          nodePinIds.add(outputPin);
+          nodePinDict.set(outputPin, [node.id, "output"]);
+        }
+      }
 
-          if (edge.from === edge.to) {
-            flags.foundSelfLoopConnection = true;
-          }
+      for (const edge of edges) {
+        if (edgeIds.has(edge.id)) {
+          flags.foundDuplicatedEdgeId = true;
+        }
+        edgeIds.add(edge.id);
 
-          const from = nodePinDict.get(edge.from);
-          const to = nodePinDict.get(edge.to);
-          if (from && to && from[0] === to[0]) {
-            flags.foundSelfLoopConnection = true;
-          }
-
-          if (from && to && from[1] === to[1]) {
-            flags.foundDuplicatedNodePinKind = true;
-          }
-
-          const existingEdge = edges.find((e) => e.from === edge.from && e.to === edge.to);
-          if (existingEdge && existingEdge.id !== edge.id) {
-            flags.foundDuplicatedEdge = true;
-          }
+        if (edge.from === edge.to) {
+          flags.foundSelfLoopConnection = true;
         }
 
-        if (Object.entries(flags).some(([_, value]) => value)) {
-          throw new Attempt.Abort("CircuitEditorUsecase.isValidData", "Invalid data.");
+        const from = nodePinDict.get(edge.from);
+        const to = nodePinDict.get(edge.to);
+        if (from && to && from[0] === to[0]) {
+          flags.foundSelfLoopConnection = true;
         }
 
-        return { ok: true, value: undefined } as const;
-      },
-      (err: unknown) => {
-        if (err instanceof Attempt.Abort) {
-          const messages = Object.entries(flags)
-            .filter(([_, value]) => value)
-            .map(([key]) => key);
-
-          return {
-            ok: false,
-            error: new CircuitEditorUsecaseGenerateNewCircuitDataError(`${messages.join(", ")}.`, { cause: err }),
-          } as const;
+        if (from && to && from[1] === to[1]) {
+          flags.foundDuplicatedNodePinKind = true;
         }
+
+        const existingEdge = edges.find((e) => e.from === edge.from && e.to === edge.to);
+        if (existingEdge && existingEdge.id !== edge.id) {
+          flags.foundDuplicatedEdge = true;
+        }
+      }
+
+      if (Object.entries(flags).some(([_, value]) => value)) {
+        throw new CircuitEditorUsecaseError("Detected invalid data.");
+      }
+
+      return { ok: true, value: undefined };
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitEditorUsecaseError) {
+        const messages = Object.entries(flags)
+          .filter(([_, value]) => value)
+          .map(([key]) => key);
 
         return {
           ok: false,
-          error: err,
-        } as const;
-      },
-    );
+          error: new CircuitEditorUsecaseError(`${messages.join(", ")}.`, { cause: err }),
+        };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitEditorUsecaseError("Unknown error occurred while validating circuit data."),
+      };
+    }
   }
 }

--- a/src/usecase/circuitEditorUsecase.ts
+++ b/src/usecase/circuitEditorUsecase.ts
@@ -27,7 +27,7 @@ export class CircuitEditorUsecase implements ICircuitEditorUsecase {
         throw new CircuitEditorUsecaseError("Failed to add circuit.", { cause: res.error });
       }
 
-      return { ok: true, value: undefined } as const;
+      return { ok: true, value: undefined };
     } catch (err: unknown) {
       console.error(err);
       if (err instanceof CircuitEditorUsecaseError) {
@@ -50,7 +50,7 @@ export class CircuitEditorUsecase implements ICircuitEditorUsecase {
         throw new CircuitEditorUsecaseError("Failed to save circuit.", { cause: res.error });
       }
 
-      return { ok: true, value: undefined } as const;
+      return { ok: true, value: undefined };
     } catch (err: unknown) {
       console.error(err);
       if (err instanceof CircuitEditorUsecaseError) {
@@ -73,7 +73,7 @@ export class CircuitEditorUsecase implements ICircuitEditorUsecase {
         throw new CircuitEditorUsecaseError("Failed to delete circuit.", { cause: res.error });
       }
 
-      return { ok: true, value: undefined } as const;
+      return { ok: true, value: undefined };
     } catch (err: unknown) {
       console.error(err);
       if (err instanceof CircuitEditorUsecaseError) {

--- a/src/usecase/circuitParserUsecase.ts
+++ b/src/usecase/circuitParserUsecase.ts
@@ -1,11 +1,9 @@
+import type { CircuitGraphData } from "@/domain/model/entity/circuitGraphData";
+import type { CircuitGuiData } from "@/domain/model/entity/circuitGuiData";
 import type { ICircuitParserService } from "@/domain/model/service/ICircuitParserService";
-import type {
-  ICircuitParserUsecase,
-  ICircuitParserUsecaseParseToGraphDataOutput,
-  ICircuitParserUsecaseParseToGuiDataOutput,
-} from "@/domain/model/usecase/ICircuitParserUsecase";
+import { CircuitParserUsecaseError, type ICircuitParserUsecase } from "@/domain/model/usecase/ICircuitParserUsecase";
 import type { CircuitData } from "@/domain/model/valueObject/circuitData";
-import { Attempt } from "@/utils/attempt";
+import type { Result } from "@/utils/result";
 
 interface CircuitParserUsecaseDependencies {
   circuitParserService: ICircuitParserService;
@@ -18,39 +16,49 @@ export class CircuitParserUsecase implements ICircuitParserUsecase {
     this.circuitParserService = circuitParserService;
   }
 
-  parseToGuiData(circuitData: CircuitData): ICircuitParserUsecaseParseToGuiDataOutput {
-    return Attempt.proceed(
-      () => {
-        const res = this.circuitParserService.parseToGuiData(circuitData);
-        if (!res.ok) {
-          throw new Attempt.Abort("CircuitParserUsecase.parseToGuiData", "Failed to parse circuit data.", {
-            cause: res.error,
-          });
-        }
+  parseToGuiData(circuitData: CircuitData): Result<CircuitGuiData, CircuitParserUsecaseError> {
+    try {
+      const res = this.circuitParserService.parseToGuiData(circuitData);
+      if (!res.ok) {
+        throw new CircuitParserUsecaseError("Failed to parse circuit data.", {
+          cause: res.error,
+        });
+      }
 
-        return { ok: true, value: res.value } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      return { ok: true, value: res.value };
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitParserUsecaseError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitParserUsecaseError("Unknown error occurred while parsing circuit data.", { cause: err }),
+      };
+    }
   }
 
-  parseToGraphData(circuitData: CircuitData): ICircuitParserUsecaseParseToGraphDataOutput {
-    return Attempt.proceed(
-      () => {
-        const res = this.circuitParserService.parseToGraphData(circuitData);
-        if (!res.ok) {
-          throw new Attempt.Abort("CircuitParserUsecase.parseToGraphData", "Failed to parse circuit data.", {
-            cause: res.error,
-          });
-        }
+  parseToGraphData(circuitData: CircuitData): Result<CircuitGraphData, CircuitParserUsecaseError> {
+    try {
+      const res = this.circuitParserService.parseToGraphData(circuitData);
+      if (!res.ok) {
+        throw new CircuitParserUsecaseError("Failed to parse circuit data.", {
+          cause: res.error,
+        });
+      }
 
-        return { ok: true, value: res.value } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      return { ok: true, value: res.value };
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof CircuitParserUsecaseError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitParserUsecaseError("Unknown error occurred while parsing circuit data.", { cause: err }),
+      };
+    }
   }
 }

--- a/src/usecase/generateCircuitEmulatorServiceClientUsecase.ts
+++ b/src/usecase/generateCircuitEmulatorServiceClientUsecase.ts
@@ -42,7 +42,7 @@ export class GenerateCircuitEmulatorServiceClientUsecase implements IGenerateCir
 
       return {
         ok: false,
-        error: new CircuitParserUsecaseError("Unknown error occurred while parsing circuit data.", { cause: err }),
+        error: new CircuitParserUsecaseError("Unknown error occurred while generating circuit data.", { cause: err }),
       };
     }
   }

--- a/src/usecase/generateCircuitEmulatorServiceClientUsecase.ts
+++ b/src/usecase/generateCircuitEmulatorServiceClientUsecase.ts
@@ -1,10 +1,12 @@
 import type { CircuitGraphData } from "@/domain/model/entity/circuitGraphData";
-import type {
-  IGenerateCircuitEmulatorServiceClientUsecase,
-  IGenerateCircuitEmulatorServiceClientUsecaseGenerateOutput,
+import type { ICircuitEmulatorService } from "@/domain/model/service/ICircuitEmulatorService";
+import { CircuitParserUsecaseError } from "@/domain/model/usecase/ICircuitParserUsecase";
+import {
+  GenerateCircuitEmulatorServiceClientUsecaseError,
+  type IGenerateCircuitEmulatorServiceClientUsecase,
 } from "@/domain/model/usecase/IGenerateCircuitEmulatorServiceClientUsecase";
 import type { CircuitEmulatorService } from "@/domain/service/circuitEmulatorService";
-import { Attempt } from "@/utils/attempt";
+import type { Result } from "@/utils/result";
 
 interface GenerateCircuitEmulatorServiceClientUsecaseDependencies {
   circuitEmulatorService: typeof CircuitEmulatorService;
@@ -17,28 +19,31 @@ export class GenerateCircuitEmulatorServiceClientUsecase implements IGenerateCir
     this.circuitEmulatorService = circuitEmulatorService;
   }
 
-  generate(circuitGraphData: CircuitGraphData): IGenerateCircuitEmulatorServiceClientUsecaseGenerateOutput {
-    return Attempt.proceed(
-      () => {
-        const res = this.circuitEmulatorService.from(circuitGraphData);
-        if (!res.ok) {
-          throw new Attempt.Abort(
-            "GenerateCircuitEmulatorServiceClientUsecase.generate",
-            "Failed to generate circuit emulator service client.",
-            {
-              cause: res.error,
-            },
-          );
-        }
+  generate(
+    circuitGraphData: CircuitGraphData,
+  ): Result<ICircuitEmulatorService, GenerateCircuitEmulatorServiceClientUsecaseError> {
+    try {
+      const res = this.circuitEmulatorService.from(circuitGraphData);
+      if (!res.ok) {
+        throw new GenerateCircuitEmulatorServiceClientUsecaseError(
+          "Failed to generate circuit emulator service client.",
+          {
+            cause: res.error,
+          },
+        );
+      }
 
-        return { ok: true, value: res.value } as const;
-      },
-      (err: unknown) => {
-        return {
-          ok: false,
-          error: err,
-        } as const;
-      },
-    );
+      return { ok: true, value: res.value };
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof GenerateCircuitEmulatorServiceClientUsecaseError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new CircuitParserUsecaseError("Unknown error occurred while parsing circuit data.", { cause: err }),
+      };
+    }
   }
 }

--- a/src/usecase/getCircuitDetailUsecase.ts
+++ b/src/usecase/getCircuitDetailUsecase.ts
@@ -1,10 +1,11 @@
+import type { Circuit } from "@/domain/model/aggregate/circuit";
 import type { ICircuitDetailQueryService } from "@/domain/model/queryService/ICircuitDetailQueryService";
-import type {
-  IGetCircuitDetailUsecase,
-  IGetCircuitDetailUsecaseGetByIdOutput,
+import {
+  GetCircuitDetailUsecaseError,
+  type IGetCircuitDetailUsecase,
 } from "@/domain/model/usecase/IGetCircuitDetailUsecase";
 import type { CircuitId } from "@/domain/model/valueObject/circuitId";
-import { Attempt } from "@/utils/attempt";
+import type { Result } from "@/utils/result";
 
 interface GetCircuitDeailUsecaseDependencies {
   circuitDetailQueryService: ICircuitDetailQueryService;
@@ -17,21 +18,26 @@ export class GetCircuitDetailUsecase implements IGetCircuitDetailUsecase {
     this.circuitDetailQueryService = circuitDetailQueryService;
   }
 
-  async getById(id: CircuitId): Promise<IGetCircuitDetailUsecaseGetByIdOutput> {
-    return await Attempt.asyncProceed(
-      async () => {
-        const res = await this.circuitDetailQueryService.getById(id);
-        if (!res.ok) {
-          throw new Attempt.Abort("GetCircuitDetailUsecase.getById", `Failed to get circuit. Id: ${id}`, {
-            cause: res.error,
-          });
-        }
+  async getById(id: CircuitId): Promise<Result<Circuit, GetCircuitDetailUsecaseError>> {
+    try {
+      const res = await this.circuitDetailQueryService.getById(id);
+      if (!res.ok) {
+        throw new GetCircuitDetailUsecaseError(`Failed to get circuit. Id: ${id}`, {
+          cause: res.error,
+        });
+      }
 
-        return { ok: true, value: res.value } as const;
-      },
-      (err: unknown) => {
-        return { ok: false, error: err } as const;
-      },
-    );
+      return { ok: true, value: res.value } as const;
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof GetCircuitDetailUsecaseError) {
+        return { ok: false, error: err };
+      }
+
+      return {
+        ok: false,
+        error: new GetCircuitDetailUsecaseError("Unknown error occurred while getting circuit detail.", { cause: err }),
+      };
+    }
   }
 }

--- a/src/utils/attempt.ts
+++ b/src/utils/attempt.ts
@@ -52,7 +52,6 @@ export namespace Attempt {
 
   const logger = (err: unknown) => {
     switch (true) {
-      case err instanceof ModelValidationError:
       case err instanceof Abort: {
         console.error(err);
         break;
@@ -63,13 +62,6 @@ export namespace Attempt {
       }
     }
   };
-
-  export class ModelValidationError extends Error {
-    constructor(modelName: string, received: unknown) {
-      super(`Invalid model: ${modelName}. Received: ${JSON.stringify(received)}`);
-      this.name = "ModelValidationError";
-    }
-  }
 
   export class Abort extends Error {
     readonly tag: string | undefined;

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -1,1 +1,1 @@
-export type Result<T> = { ok: true; value: T } | { ok: false; error: unknown };
+export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
 			"@/*": ["./src/*"]
 		}
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "eslint.config.js"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Abstract

Refactored overall source code with replaceing `Attempt` with `try catch`. 
 
# Change logs

- Install eslint
- Update dependencies
- Add custom lint rule of eslint (refer `<root>/eslint-rules-plugin`)
- Remove `utils/Attempt.ts`
- Replace `Attempt.prceeed`, `Attempt.asyncPrceeed` with `try catch`

# notes

eslint was introduced due to lack of biome's custom lint rules fetures. Therefore, eslint might be replaced with biome's cutom rule in the future. But it is not planned at this time.
